### PR TITLE
Sam profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,20 @@ This profile creates:
 
 1. A sam service account for use by Sam instances
 
-This profile must be applied with `-a`, which uses your local application default
-credentials instead of a terraform service account. To generate your own ADC, run
+In projects in which the Terraform SA has Owner permission, this profile should be
+run normally (without `-a`). In projects in which the Terraform SA does NOT have
+Owner, you must be an owner yourself and apply this profile with `-a`,
+which uses your local application default credentials instead of a terraform
+service account. To generate your own ADC, run
 `gcloud auth application-default login` and follow the instructions.
 
 ```
 # deploy example
-./dsp-k8s-deploy/application-deploy.sh -j broad-wb-perf2.json -p sam-sa -a
+./dsp-k8s-deploy/application-deploy.sh -j broad-wb-perf2.json -p sam-sa
 # render example
-./dsp-k8s-deploy/application-render.sh -j broad-wb-perf2.json -p sam-sa -a
+./dsp-k8s-deploy/application-render.sh -j broad-wb-perf2.json -p sam-sa
 # teardown example
-./dsp-k8s-deploy/application-teardown.sh -j broad-wb-perf2.json -p sam-sa -a
+./dsp-k8s-deploy/application-teardown.sh -j broad-wb-perf2.json -p sam-sa
 ```
 
 
@@ -165,17 +168,21 @@ This profile creates:
 
 1. A thurloe service account for use by Thurloe instances
 
-This profile must be applied with `-a`, which uses your local application default
-credentials instead of a terraform service account. To generate your own ADC, run
+In projects in which the Terraform SA has Owner permission, this profile should be
+run normally (without `-a`). In projects in which the Terraform SA does NOT have
+Owner, you must be an owner yourself and apply this profile with `-a`,
+which uses your local application default credentials instead of a terraform
+service account. To generate your own ADC, run
 `gcloud auth application-default login` and follow the instructions.
+
 
 ```
 # deploy example
-./dsp-k8s-deploy/application-deploy.sh -j broad-wb-perf2.json -p thurloe-sa -a
+./dsp-k8s-deploy/application-deploy.sh -j broad-wb-perf2.json -p thurloe-sa
 # render example
-./dsp-k8s-deploy/application-render.sh -j broad-wb-perf2.json -p thurloe-sa -a
+./dsp-k8s-deploy/application-render.sh -j broad-wb-perf2.json -p thurloe-sa
 # teardown example
-./dsp-k8s-deploy/application-teardown.sh -j broad-wb-perf2.json -p thurloe-sa -a
+./dsp-k8s-deploy/application-teardown.sh -j broad-wb-perf2.json -p thurloe-sa
 ```
 
 ## `thurloe`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,28 @@ This profile creates two SSL certificates.
 ./dsp-k8s-deploy/application-teardown.sh -j broad-wb-perf2.json -p ssl
 ```
 
+## `sam`
+
+This profile creates:
+
+1. An instance group with one instance
+2. A DNS record for the instance
+3. A config bucket for storing Sam configs
+4. A load balancer in front of the instance group
+5. A DNS record for the load balancer
+
+_note this profile does not create an OpenDJ instance;
+that must be done separately._
+
+```
+# deploy example
+./dsp-k8s-deploy/application-deploy.sh -j broad-wb-perf2.json -p sam
+# render example
+./dsp-k8s-deploy/application-render.sh -j broad-wb-perf2.json -p sam
+# teardown example
+./dsp-k8s-deploy/application-teardown.sh -j broad-wb-perf2.json -p sam
+```
+
 ### `thurloe-sa`
 
 This profile creates:
@@ -144,7 +166,7 @@ This profile creates:
 1. A cloudsql database for Thurloe
 2. A DNS record pointing to the cloudsql db
 3. An instance group with one instance
-4. A DNS record for the instancee
+4. A DNS record for the instance
 5. A config bucket for storing Thurloe configs
 6. A load balancer in front of the instance group
 7. A DNS record for the load balancer

--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ This profile creates two SSL certificates.
 # teardown example
 ./dsp-k8s-deploy/application-teardown.sh -j broad-wb-perf2.json -p ssl
 ```
+### `sam-sa`
+
+This profile creates:
+
+1. A sam service account for use by Sam instances
+
+This profile must be applied with `-a`, which uses your local application default
+credentials instead of a terraform service account. To generate your own ADC, run
+`gcloud auth application-default login` and follow the instructions.
+
+```
+# deploy example
+./dsp-k8s-deploy/application-deploy.sh -j broad-wb-perf2.json -p sam-sa -a
+# render example
+./dsp-k8s-deploy/application-render.sh -j broad-wb-perf2.json -p sam-sa -a
+# teardown example
+./dsp-k8s-deploy/application-teardown.sh -j broad-wb-perf2.json -p sam-sa -a
+```
+
 
 ## `sam`
 

--- a/profiles/sam-sa/terraform/sam/sa.tf
+++ b/profiles/sam-sa/terraform/sam/sa.tf
@@ -1,0 +1,5 @@
+# Create configuration bucket
+resource "google_service_account" "app_config" {
+  account_id   = "${var.owner}-${var.service}"
+  project      = "${var.google_project}"
+}

--- a/profiles/sam-sa/terraform/sam/variables.tf.ctmpl
+++ b/profiles/sam-sa/terraform/sam/variables.tf.ctmpl
@@ -1,0 +1,15 @@
+#
+# Profile Vars
+#
+variable "google_project" {
+  default = "{{env "GOOGLE_PROJECT"}}"
+  description = "The google project as specified in the application json"
+}
+variable "owner" {
+  default = "{{env "OWNER"}}"
+  description = "The owner from the application json"
+}
+variable "service" {
+  default = "{{env "SERVICE"}}"
+  description = "The name of the service within the profile"
+}

--- a/profiles/sam/terraform/sam/api-services.tf
+++ b/profiles/sam/terraform/sam/api-services.tf
@@ -6,6 +6,7 @@ module "enable-services" {
   }
   project     = "${var.google_project}"
   services    = [
+    "dns.googleapis.com",
     "stackdriver.googleapis.com",
     "logging.googleapis.com",
     "datastore.googleapis.com"

--- a/profiles/sam/terraform/sam/api-services.tf
+++ b/profiles/sam/terraform/sam/api-services.tf
@@ -6,7 +6,6 @@ module "enable-services" {
   }
   project     = "${var.google_project}"
   services    = [
-    "dns.googleapis.com",
     "stackdriver.googleapis.com",
     "logging.googleapis.com",
     "datastore.googleapis.com"

--- a/profiles/sam/terraform/sam/api-services.tf
+++ b/profiles/sam/terraform/sam/api-services.tf
@@ -1,0 +1,13 @@
+module "enable-services" {
+  source      = "github.com/broadinstitute/terraform-shared.git//terraform-modules/api-services?ref=services-0.1.2"
+  enable_flag = "1"
+  providers {
+    google.target = "google"
+  }
+  project     = "${var.google_project}"
+  services    = [
+    "stackdriver.googleapis.com",
+    "logging.googleapis.com",
+    "datastore.googleapis.com"
+  ]
+}

--- a/profiles/sam/terraform/sam/sam.tf
+++ b/profiles/sam/terraform/sam/sam.tf
@@ -14,11 +14,11 @@ module "instances" {
   instance_labels = {
     "app" = "${var.service}",
     "owner" = "${var.owner}",
-    "role" = "frontend",
     "ansible_branch" = "master",
     "ansible_project" = "terra-env",
   }
   instance_tags = "${var.instance_tags}"
+  # depends_on   = ["dns", "ssl", "sam-sa"]
 }
 
 # Service config bucket

--- a/profiles/sam/terraform/sam/sam.tf
+++ b/profiles/sam/terraform/sam/sam.tf
@@ -1,0 +1,86 @@
+
+# Docker instance(s)
+module "instances" {
+  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/docker-instance?ref=docker-instance-0.1.1"
+
+  providers {
+    google.target =  "google"
+  }
+  project       = "${var.google_project}"
+  instance_name = "${var.service}"
+  instance_size = "${var.instance_size}"
+  instance_service_account = "${data.google_service_account.config_reader.email}"
+  instance_network_name = "${data.google_compute_network.terra-env-network.name}"
+  instance_labels = {
+    "app" = "${var.service}",
+    "owner" = "${var.owner}",
+    "role" = "frontend",
+    "ansible_branch" = "master",
+    "ansible_project" = "terra-env",
+  }
+  instance_tags = "${var.instance_tags}"
+}
+
+# Service config bucket
+resource "google_storage_bucket" "config-bucket" {
+  name       = "${var.owner}-${var.service}-config"
+  project    = "${var.google_project}"
+  versioning = {
+    enabled = "true"
+  }
+  # Do we want to add encryption to this bucket?
+  force_destroy = true
+  labels = {
+    "app" = "${var.service}",
+    "owner" = "${var.owner}",
+    "role" = "config"
+  }
+}
+
+# Grant service account access to the config bucket
+resource "google_storage_bucket_iam_member" "app_config" {
+  bucket = "${google_storage_bucket.config-bucket.name}"
+  role   = "${element(var.storage_bucket_roles, count.index)}"
+  member = "serviceAccount:${data.google_service_account.config_reader.email}"
+}
+
+# Instance DNS
+resource "google_dns_record_set" "instance-dns" {
+  provider     = "google"
+  managed_zone = "${data.google_dns_managed_zone.terra-env-dns-zone.name}"
+  name         = "${format("${var.service}-%02d.%s",count.index+1,data.google_dns_managed_zone.terra-env-dns-zone.dns_name)}"
+  type         = "A"
+  ttl          = "${var.dns_ttl}"
+  rrdatas      = [ "${element(module.instances.instance_public_ips, count.index)}" ]
+  depends_on   = ["module.instances", "data.google_dns_managed_zone.terra-env-dns-zone"]
+}
+
+# Load Balancer
+#  need to figure out dependency in order to ensure proper order - instances 
+#  must be created before load balancer
+#  Potential solution: https://github.com/hashicorp/terraform/issues/1178#issuecomment-207369534
+module "load-balancer" {
+  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/http-load-balancer?ref=http-load-balancer-0.1.0"
+
+  providers {
+    google.target =  "google"
+  }
+  project       = "${var.google_project}"
+  load_balancer_name = "${var.owner}-${var.service}"
+  load_balancer_ssl_certificates = [
+    "${data.google_compute_ssl_certificate.terra-env-wildcard-ssl-certificate-red.name}",
+    "${data.google_compute_ssl_certificate.terra-env-wildcard-ssl-certificate-black.name}"
+  ]
+  load_balancer_instance_groups = "${element(module.instances.instance_instance_group,0)}"
+}
+
+# Service DNS
+resource "google_dns_record_set" "app-dns" {
+  provider     = "google"
+  managed_zone = "${data.google_dns_managed_zone.terra-env-dns-zone.name}"
+  name         = "${var.service}.${data.google_dns_managed_zone.terra-env-dns-zone.dns_name}"
+  type         = "A"
+  ttl          = "${var.dns_ttl}"
+  rrdatas      = [ "${module.load-balancer.load_balancer_public_ip}" ]
+  depends_on   = ["module.load-balancer", "data.google_dns_managed_zone.terra-env-dns-zone"]
+}

--- a/profiles/sam/terraform/sam/variables.tf.ctmpl
+++ b/profiles/sam/terraform/sam/variables.tf.ctmpl
@@ -1,53 +1,13 @@
 #
 # Profile Vars
 #
-variable "environment" {
-  default = "{{env "ENVIRONMENT"}}"
-  description = "The environment specified in the application json"
-}
 variable "google_project" {
   default = "{{env "GOOGLE_PROJECT"}}"
   description = "The google project as specified in the application json"
 }
-variable "google_region" {
-  default = "{{env "GOOGLE_REGION"}}"
-  description = "The google region as specified in the application json"
-}
-variable "google_zone" {
-  default = "{{env "GOOGLE_ZONE"}}"
-  description = "The google zone as specified by `GOOGLE_REGION` and the application json"
-}
-variable "dns_zone" {
-  default = "{{env "DNS_ZONE"}}"
-  description = "The full DNS zone without a trailing . as specified in the application json"
-}
-variable "dns_zone_name" {
-  default = "{{env "DNS_ZONE_NAME"}}"
-  description = "The name of the DNS zone (its google id) as specified in the application json"
-}
-variable "latest_k8s_master_version" {
-  default = "{{env "LATEST_K8S_MASTER_VERSION"}}"
-  description = "A dynamically looked up most recent available gke version"
-}
-variable "latest_k8s_node_version" {
-  default = "{{env "LATEST_K8S_NODE_VERSION"}}"
-  description = "A dynamically looked up most recent available gke version"
-}
-variable "cluster_name" {
-  default = "{{env "CLUSTER_NAME"}}"
-  description = "The name of the cluster in GKE as specified in the application json"
-}
-variable "kubectl_context" {
-  default = "{{env "KUBECTL_CONTEXT"}}"
-  description = "Either the value of `.clusters.default.context` in application json or the standard GKE kubectl context for `GOOGLE_PROJECT`, `GOOGLE_ZONE`, and `CLUSTER_NAME`"
-}
 variable "owner" {
   default = "{{env "OWNER"}}"
   description = "The owner from the application json"
-}
-variable "application_name" {
-  default = "{{env "APPLICATION_NAME"}}"
-  description = "Name from the application json"
 }
 variable "service" {
   default = "{{env "SERVICE"}}"
@@ -107,75 +67,11 @@ variable "instance_tags" {
 }
 
 #
-# Sam - DNS Vars
-#
-variable "load_balancer_dns_cname_record_flag" {
-  default = "0"
-  description = "Enable DNS CNAME record for default sam load balancer in an env. Should be set as a vault env override for each env."
-}
-
-variable "load_balancer_dns_cname_record_service_hostname" {
-  default = ""
-  description = "DNS CNAME record service hostname for default sam load balancer in an env. Should be set as a vault env override for each env."
-}
-
-variable "load_balancer_dns_cname_record_target_hostname" {
-  default = ""
-  description = "DNS CNAME record target hostname for default sam load balancer in an env. Should be set as a vault env override for each env."
-}
-
-variable "app_dns_cname_record_flag" {
-  default = "0"
-  description = "Enable DNS CNAME record for default sam instance in an env. Should be set as a vault env override for each env."
-}
-
-variable "app_dns_cname_record_service_hostname" {
-  default = ""
-  description = "DNS CNAME record service hostname for default sam instance in an env. Should be set as a vault env override for each env."
-}
-
-variable "app_dns_cname_record_target_hostname" {
-  default = ""
-  description = "DNS CNAME record target hostname for default sam instance in an env. Should be set as a vault env override for each env."
-}
-
-
-#
 # Sam Service Cluster 
 #
-variable "num_hosts" {
-  default = "0"
-  description = "The default number of Sam service hosts per environment"
-}
-
 variable "instance_size" {
   default = "{{ if env "SAM_INSTANCE_SIZE" | parseBool}}{{ env "SAM_INSTANCE_SIZE" }}{{ else }}custom-4-5120{{ end }}"
   description = "The default size of Sam service hosts"
-}
-
-variable "image_name" {
-  default = "centos-7-v20190423"
-  description = "The default GCE OS platform image for Sam 100 service cluster"
-}
-
-variable "metadata_startup_script" {
-   default = "metadata/centos7-docker2.sh"
-   description = "Default metadata startup script used when bootstrapping Sam 100 instances"
-}
-
-variable "allow_stopping_for_update" {
-   default = "false"
-   description = "If set to true, the instance can be stopped for certain changes (common example: resizing the instance)."
-}
-
-variable "100_instance_group_load_balancer_name" {
-  default = "0"
-  description = "Determines the name of the load balancer to which the sam 100 instance group should be added. Typical value will be the same as the public service name of the load balancer. Examples: sam-200-lb, sam-load-balancer-100"
-}
-
-variable "100_instance_group_unmanaged_enable" {
-  default = "0"
-  description = "Enables GCE instance group for Sam 100 service cluster"
 }
 
 #
@@ -190,14 +86,8 @@ variable "storage_bucket_roles" {
 }
 
 #
-# Sam Common Load Balancer (replaces sam-NNN-lb entities)
+# Sam - DNS Vars
 #
-variable "load_balancer_100_enable" {
-  default = "0"
-  description = "Enables GCE common load balancer 100 for one or more Sam NNN service clusters"
-}
-
-
 variable "dns_ttl" {
    default = "300"
 }

--- a/profiles/sam/terraform/sam/variables.tf.ctmpl
+++ b/profiles/sam/terraform/sam/variables.tf.ctmpl
@@ -1,0 +1,203 @@
+#
+# Profile Vars
+#
+variable "environment" {
+  default = "{{env "ENVIRONMENT"}}"
+  description = "The environment specified in the application json"
+}
+variable "google_project" {
+  default = "{{env "GOOGLE_PROJECT"}}"
+  description = "The google project as specified in the application json"
+}
+variable "google_region" {
+  default = "{{env "GOOGLE_REGION"}}"
+  description = "The google region as specified in the application json"
+}
+variable "google_zone" {
+  default = "{{env "GOOGLE_ZONE"}}"
+  description = "The google zone as specified by `GOOGLE_REGION` and the application json"
+}
+variable "dns_zone" {
+  default = "{{env "DNS_ZONE"}}"
+  description = "The full DNS zone without a trailing . as specified in the application json"
+}
+variable "dns_zone_name" {
+  default = "{{env "DNS_ZONE_NAME"}}"
+  description = "The name of the DNS zone (its google id) as specified in the application json"
+}
+variable "latest_k8s_master_version" {
+  default = "{{env "LATEST_K8S_MASTER_VERSION"}}"
+  description = "A dynamically looked up most recent available gke version"
+}
+variable "latest_k8s_node_version" {
+  default = "{{env "LATEST_K8S_NODE_VERSION"}}"
+  description = "A dynamically looked up most recent available gke version"
+}
+variable "cluster_name" {
+  default = "{{env "CLUSTER_NAME"}}"
+  description = "The name of the cluster in GKE as specified in the application json"
+}
+variable "kubectl_context" {
+  default = "{{env "KUBECTL_CONTEXT"}}"
+  description = "Either the value of `.clusters.default.context` in application json or the standard GKE kubectl context for `GOOGLE_PROJECT`, `GOOGLE_ZONE`, and `CLUSTER_NAME`"
+}
+variable "owner" {
+  default = "{{env "OWNER"}}"
+  description = "The owner from the application json"
+}
+variable "application_name" {
+  default = "{{env "APPLICATION_NAME"}}"
+  description = "Name from the application json"
+}
+variable "service" {
+  default = "{{env "SERVICE"}}"
+  description = "The name of the service within the profile"
+}
+
+#
+# Dependency Profiles' Vars
+#
+# DNS
+variable "google_dns_zone" {
+  default = "{{env "OWNER"}}-terra-dns"
+}
+data "google_dns_managed_zone" "terra-env-dns-zone" {
+  name = "${var.google_dns_zone}"
+}
+# SSL
+variable "google_compute_ssl_certificate_red" {
+  default = "{{env "OWNER"}}-terra-env-wildcard-ssl-certificate-red"
+}
+variable "google_compute_ssl_certificate_black" {
+  default = "{{env "OWNER"}}-terra-env-wildcard-ssl-certificate-black"
+}
+data "google_compute_ssl_certificate" "terra-env-wildcard-ssl-certificate-red" {
+  name = "${var.google_compute_ssl_certificate_red}"
+}
+data "google_compute_ssl_certificate" "terra-env-wildcard-ssl-certificate-black" {
+  name = "${var.google_compute_ssl_certificate_black}"
+}
+# Network
+variable "google_network_name" {
+  default = "{{env "OWNER"}}-terra-network"
+}
+data "google_compute_network" "terra-env-network" {
+  name = "${var.google_network_name}"
+}
+# Sam SA
+variable "config_reader_service_account" {
+  default = "{{env "OWNER"}}-{{env "SERVICE"}}"
+}
+data "google_service_account" "config_reader" {
+  account_id = "${var.config_reader_service_account}"
+}
+
+
+#
+# Sam - Common Vars
+#
+variable "instance_tags" {
+  default = [
+    "{{env "OWNER"}}-terra-{{env "SERVICE"}}",
+    "http-server",
+    "https-server",
+    "gce-lb-instance-group-member"
+  ]
+  description = "The default instance tags"
+}
+
+#
+# Sam - DNS Vars
+#
+variable "load_balancer_dns_cname_record_flag" {
+  default = "0"
+  description = "Enable DNS CNAME record for default sam load balancer in an env. Should be set as a vault env override for each env."
+}
+
+variable "load_balancer_dns_cname_record_service_hostname" {
+  default = ""
+  description = "DNS CNAME record service hostname for default sam load balancer in an env. Should be set as a vault env override for each env."
+}
+
+variable "load_balancer_dns_cname_record_target_hostname" {
+  default = ""
+  description = "DNS CNAME record target hostname for default sam load balancer in an env. Should be set as a vault env override for each env."
+}
+
+variable "app_dns_cname_record_flag" {
+  default = "0"
+  description = "Enable DNS CNAME record for default sam instance in an env. Should be set as a vault env override for each env."
+}
+
+variable "app_dns_cname_record_service_hostname" {
+  default = ""
+  description = "DNS CNAME record service hostname for default sam instance in an env. Should be set as a vault env override for each env."
+}
+
+variable "app_dns_cname_record_target_hostname" {
+  default = ""
+  description = "DNS CNAME record target hostname for default sam instance in an env. Should be set as a vault env override for each env."
+}
+
+
+#
+# Sam Service Cluster 
+#
+variable "num_hosts" {
+  default = "0"
+  description = "The default number of Sam service hosts per environment"
+}
+
+variable "instance_size" {
+  default = "{{ if env "SAM_INSTANCE_SIZE" | parseBool}}{{ env "SAM_INSTANCE_SIZE" }}{{ else }}custom-4-5120{{ end }}"
+  description = "The default size of Sam service hosts"
+}
+
+variable "image_name" {
+  default = "centos-7-v20190423"
+  description = "The default GCE OS platform image for Sam 100 service cluster"
+}
+
+variable "metadata_startup_script" {
+   default = "metadata/centos7-docker2.sh"
+   description = "Default metadata startup script used when bootstrapping Sam 100 instances"
+}
+
+variable "allow_stopping_for_update" {
+   default = "false"
+   description = "If set to true, the instance can be stopped for certain changes (common example: resizing the instance)."
+}
+
+variable "100_instance_group_load_balancer_name" {
+  default = "0"
+  description = "Determines the name of the load balancer to which the sam 100 instance group should be added. Typical value will be the same as the public service name of the load balancer. Examples: sam-200-lb, sam-load-balancer-100"
+}
+
+variable "100_instance_group_unmanaged_enable" {
+  default = "0"
+  description = "Enables GCE instance group for Sam 100 service cluster"
+}
+
+#
+# Sam Service Config Bucket
+#
+variable "storage_bucket_roles" {
+  type = "list"
+
+  default = [
+    "roles/storage.legacyBucketReader"
+  ]
+}
+
+#
+# Sam Common Load Balancer (replaces sam-NNN-lb entities)
+#
+variable "load_balancer_100_enable" {
+  default = "0"
+  description = "Enables GCE common load balancer 100 for one or more Sam NNN service clusters"
+}
+
+
+variable "dns_ttl" {
+   default = "300"
+}

--- a/profiles/thurloe/terraform/thurloe/thurloe.tf
+++ b/profiles/thurloe/terraform/thurloe/thurloe.tf
@@ -43,7 +43,6 @@ module "instances" {
   instance_labels = {
     "app" = "${var.service}",
     "owner" = "${var.owner}",
-    "role" = "frontend",
     "ansible_branch" = "master",
     "ansible_project" = "terra-env",
   }


### PR DESCRIPTION
Terraform profiles for Sam and the Sam SA. Based off the Thurloe profiles.

There is a lot of copy-paste boilerplate in `variables.tf` between Sam and Thurloe; in Slack discussion I'd like to push that off for a future PR/refactor.

To get this working in `broad-wb-perf2` from scratch, I had to:
* set up kubectl locally by following kubernetes.md
* manually enable Cloud DNS via Cloud Console
* apply the `dns` profile
* apply the `ssl` profile
* apply the `network` profile
* apply the `sam-sa`  profile (which I ran normally, not with ADC, i.e. without `-a`)
* apply the `sam` profile

would it be better to add `dns`, `ssl`, `network`, `sam-sa` as dependencies somewhere in the `sam` profile? Is this possible?


