### PR TITLE
Rl populate vault

### DIFF
--- a/broad-wb-malkov.json
+++ b/broad-wb-malkov.json
@@ -5,6 +5,14 @@
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",
+  "global_vars": {
+    "env": {
+      "VAULT_PATH_PREFIX": "secret/dsde/firecloud/ephemeral/broad-wb-malkov"
+    },
+    "vault": {
+      "policy": "dsde-write"
+    }
+  },
   "profile_vars": {
     "thurloe-configs": {
       "env": {

--- a/broad-wb-malkov.json
+++ b/broad-wb-malkov.json
@@ -1,7 +1,7 @@
 {
   "name": "terra",
   "owner": "gmalkov",
-  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:92b53bdf2d82e5",
+  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:rl_1",
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",
@@ -25,7 +25,7 @@
   },
   "environments": {
     "default": {
-      "name": "dev"
+      "name": "broad-wb-malkov"
     }
   },
   "projects": {

--- a/broad-wb-perf2.json
+++ b/broad-wb-perf2.json
@@ -5,6 +5,14 @@
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",
+  "global_vars": {
+    "env": {
+      "VAULT_PATH_PREFIX": "secret/dsde/firecloud/ephemeral/broad-wb-perf2"
+    },
+    "vault": {
+      "policy": "dsde-write"
+    }
+  },
   "profile_vars": {
     "thurloe-configs": {
       "env": {

--- a/broad-wb-perf2.json
+++ b/broad-wb-perf2.json
@@ -25,7 +25,7 @@
   },
   "environments": {
     "default": {
-      "name": "dev"
+      "name": "broad-wb-perf2"
     }
   },
   "projects": {

--- a/broad-wb-rluckom.json
+++ b/broad-wb-rluckom.json
@@ -1,11 +1,16 @@
 {
   "name": "terra",
   "owner": "broad-wb-rluckom",
-  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:92b53bdf2d82e5",
+  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:rl_1",
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",
   "profile_vars": {
+    "thurloe": {
+      "vault": {
+        "policy":"dsde-write"
+      }
+    },
     "thurloe-configs": {
       "env": {
         "APP_NAME": "thurloe",

--- a/broad-wb-rluckom.json
+++ b/broad-wb-rluckom.json
@@ -9,15 +9,14 @@
     "thurloe-configs": {
       "env": {
         "APP_NAME": "thurloe",
-        "ENVIRONMENT": "dev",
-        "FIRECLOUD_DEVELOP_GIT_BRANCH": "dev",
+        "FIRECLOUD_DEVELOP_GIT_BRANCH": "rl-thurloe-perf-db",
         "SERVICE_GIT_SHA_12_CHAR": "4c11a7177674"
       }
     }
   },
   "environments": {
     "default": {
-      "name": "dev"
+      "name": "broad-wb-rluckom"
     }
   },
   "projects": {

--- a/broad-wb-rluckom.json
+++ b/broad-wb-rluckom.json
@@ -37,7 +37,7 @@
   },
   "dns": {
     "default": {
-      "name": "broad-wb-rluckom",
+      "name": "broad-dsde-perf",
       "zone": "broad-wb-rluckom.broadinstitute.org"
     }
   },

--- a/broad-wb-rluckom.json
+++ b/broad-wb-rluckom.json
@@ -5,12 +5,15 @@
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",
-  "profile_vars": {
-    "thurloe": {
-      "vault": {
-        "policy":"dsde-write"
-      }
+  "global_vars": {
+    "env": {
+      "VAULT_PATH_PREFIX": "secret/dsde/firecloud/ephemeral/broad-wb-rluckom"
     },
+    "vault": {
+      "policy": "dsde-write"
+    }
+  },
+  "profile_vars": {
     "thurloe-configs": {
       "env": {
         "APP_NAME": "thurloe",

--- a/containers/ruby-consul-terraform/render_configs.rb
+++ b/containers/ruby-consul-terraform/render_configs.rb
@@ -111,6 +111,7 @@ if __FILE__ == $0
       "LDAP_BASE_DOMAIN" => $ldap_base_domain,
       "BUCKET_TAG" => $bucket_tag,
       "SERVICE_VERSION" => ENV.fetch("SERVICE_VERSION", ""),
+      "VAULT_PATH_PREFIX" => ENV.fetch("VAULT_PATH_PREFIX", ""),
       "DIR" => $fiab_dir
     }
     Open3.popen3(

--- a/profiles/populate-vault/terraform/populate-vault/common.tf
+++ b/profiles/populate-vault/terraform/populate-vault/common.tf
@@ -1,0 +1,4 @@
+resource "vault_generic_secret" "common_secrets" {
+  path = "${var.vault_path_prefix}/common/secrets"
+  data_json = "${var.common_secrets_json}"
+}

--- a/profiles/populate-vault/terraform/populate-vault/variables.tf.ctmpl
+++ b/profiles/populate-vault/terraform/populate-vault/variables.tf.ctmpl
@@ -1,0 +1,31 @@
+variable "environment" {
+  default = "{{env "ENVIRONMENT"}}"
+  description = "The environment specified in the application json"
+}
+
+variable "vault_path_prefix" {
+  default = "{{if (env "VAULT_PATH_PREFIX")}}{{env "VAULT_PATH_PREFIX"}}{{else}}secret/dsde/firecloud/ephemeral/{{env "ENVIRONMENT"}}{{end}}"
+  description = "Path prefix for vault secrets for this environment. MUST NOT end with trailing slash"
+}
+
+variable "google_project" {
+  default = "{{env "GOOGLE_PROJECT"}}"
+  description = "The google project as specified in the application json"
+}
+
+variable "google_region" {
+  default = "{{env "GOOGLE_REGION"}}"
+  description = "The google region as specified in the application json"
+}
+
+variable "google_zone" {
+  default = "{{env "GOOGLE_ZONE"}}"
+  description = "The google zone as specified by `GOOGLE_REGION` and the application json"
+}
+
+variable "common_secrets_json" {
+  description = "secrets from secret/dsde/firecloud/common/secrets"
+  default = <<EOT
+{{with secret "secret/dsde/firecloud/perf/common/secrets"}}{{ .Data | toJSONPretty | }}{{end}}
+EOT
+}

--- a/profiles/populate-vault/terraform/populate-vault/vault.tf
+++ b/profiles/populate-vault/terraform/populate-vault/vault.tf
@@ -1,0 +1,1 @@
+provider "vault" {}

--- a/profiles/thurloe-configs/terraform/thurloe/config.tf
+++ b/profiles/thurloe-configs/terraform/thurloe/config.tf
@@ -38,6 +38,7 @@ resource "null_resource" "config" {
       DNS_DOMAIN = "${var.config_dns_domain}"
       LDAP_BASE_DOMAIN = "${var.ldap_base_domain}"
       BUCKET_TAG = "${var.bucket_tag}"
+      VAULT_PATH_PREFIX = "${var.vault_path_prefix}"
     }
   }
 }

--- a/profiles/thurloe-configs/terraform/thurloe/variables.tf.ctmpl
+++ b/profiles/thurloe-configs/terraform/thurloe/variables.tf.ctmpl
@@ -1,3 +1,7 @@
+variable "vault_path_prefix" {
+  default = "{{if (env "VAULT_PATH_PREFIX")}}{{ env "VAULT_PATH_PREFIX"}}{{else}}secret/dsde/firecloud/ephemeral/{{env "ENVIRONMENT"}}{{end}}"
+  description = "The name of the service within the profile"
+}
 #
 # Instance data
 #

--- a/profiles/thurloe/terraform/thurloe/dns.tf
+++ b/profiles/thurloe/terraform/thurloe/dns.tf
@@ -1,0 +1,45 @@
+provider "google" {
+  alias = "dns"
+  project     = "${var.dns_project}"
+  region      = "${var.dns_region}"
+  credentials = "${file("dns_sa.json")}"
+}
+
+# Cloud SQL dns
+resource "google_dns_record_set" "mysql-instance-new" {
+  provider     = "google.dns"
+  managed_zone = "${data.google_dns_managed_zone.dns-zone.name}"
+  name         = "${var.owner}-${var.google_project}-${var.service}-mysql.${data.google_dns_managed_zone.dns-zone.dns_name}"
+  type         = "A"
+  ttl          = "${var.dns_ttl}"
+  rrdatas      = [ "${module.cloudsql.cloudsql-public-ip}" ]
+  depends_on   = ["module.cloudsql"]
+}
+
+data "google_dns_managed_zone" "dns-zone" {
+  provider = "google.dns"
+  name = "dsde-perf-broad"
+}
+
+# Instance DNS
+resource "google_dns_record_set" "instance-dns-new" {
+  provider     = "google.dns"
+  count        = "${var.instance_num_hosts}"
+  managed_zone = "${data.google_dns_managed_zone.dns-zone.name}"
+  name         = "${format("${var.owner}-${var.google_project}-${var.service}-%02d.%s",count.index+1,data.google_dns_managed_zone.dns-zone.dns_name)}"
+  type         = "A"
+  ttl          = "${var.dns_ttl}"
+  rrdatas      = [ "${element(module.instances.instance_public_ips, count.index)}" ]
+  depends_on   = ["module.instances", "data.google_dns_managed_zone.dns-zone"]
+}
+
+# Service DNS
+resource "google_dns_record_set" "app-dns-new" {
+  provider     = "google.dns"
+  managed_zone = "${data.google_dns_managed_zone.dns-zone.name}"
+  name         = "${var.owner}-${var.google_project}-${var.service}.${data.google_dns_managed_zone.dns-zone.dns_name}"
+  type         = "A"
+  ttl          = "${var.dns_ttl}"
+  rrdatas      = [ "${module.load-balancer.load_balancer_public_ip}" ]
+  depends_on   = ["module.load-balancer", "data.google_dns_managed_zone.terra-env-dns-zone"]
+}

--- a/profiles/thurloe/terraform/thurloe/dns_sa.json.ctmpl
+++ b/profiles/thurloe/terraform/thurloe/dns_sa.json.ctmpl
@@ -1,0 +1,1 @@
+{{with $project := "firecloud"}}{{with $environment := "perf" }}{{with $terraformServiceAccount := secret (printf "secret/devops/terraform/%s/%s/credentials" $environment $project)}}{{$terraformServiceAccount.Data | toJSONPretty}}{{end}}{{end}}{{end}}

--- a/profiles/thurloe/terraform/thurloe/thurloe.tf
+++ b/profiles/thurloe/terraform/thurloe/thurloe.tf
@@ -20,18 +20,6 @@ module "cloudsql" {
   }
 }
 
-# Cloud SQL dns
-resource "google_dns_record_set" "mysql-instance-old" {
-  provider     = "google"
-  count = 0
-  managed_zone = "${data.google_dns_managed_zone.terra-env-dns-zone.name}"
-  name         = "${var.owner}-${var.service}-mysql.${data.google_dns_managed_zone.terra-env-dns-zone.dns_name}"
-  type         = "A"
-  ttl          = "${var.dns_ttl}"
-  rrdatas      = [ "${module.cloudsql.cloudsql-public-ip}" ]
-  depends_on   = ["module.cloudsql", "data.google_dns_managed_zone.terra-env-dns-zone"]
-}
-
 # Docker instance(s)
 module "instances" {
   source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/docker-instance?ref=docker-instance-0.1.1"
@@ -78,18 +66,6 @@ resource "google_storage_bucket_iam_member" "app_config" {
   member = "serviceAccount:${data.google_service_account.config_reader.email}"
 }
 
-# Instance DNS
-resource "google_dns_record_set" "instance-dns-old" {
-  provider     = "google"
-  count = 0
-  managed_zone = "${data.google_dns_managed_zone.terra-env-dns-zone.name}"
-  name         = "${format("${var.service}-%02d.%s",count.index+1,data.google_dns_managed_zone.terra-env-dns-zone.dns_name)}"
-  type         = "A"
-  ttl          = "${var.dns_ttl}"
-  rrdatas      = [ "${element(module.instances.instance_public_ips, count.index)}" ]
-  depends_on   = ["module.instances", "data.google_dns_managed_zone.terra-env-dns-zone"]
-}
-
 # Load Balancer
 #  need to figure out dependency in order to ensure proper order - instances 
 #  must be created before load balancer
@@ -107,16 +83,4 @@ module "load-balancer" {
     "${data.google_compute_ssl_certificate.terra-env-wildcard-ssl-certificate-black.name}"
   ]
   load_balancer_instance_groups = "${element(module.instances.instance_instance_group,0)}"
-}
-
-# Service DNS
-resource "google_dns_record_set" "app-dns-old" {
-  provider     = "google"
-  count = 0
-  managed_zone = "${data.google_dns_managed_zone.terra-env-dns-zone.name}"
-  name         = "${var.service}.${data.google_dns_managed_zone.terra-env-dns-zone.dns_name}"
-  type         = "A"
-  ttl          = "${var.dns_ttl}"
-  rrdatas      = [ "${module.load-balancer.load_balancer_public_ip}" ]
-  depends_on   = ["module.load-balancer", "data.google_dns_managed_zone.terra-env-dns-zone"]
 }

--- a/profiles/thurloe/terraform/thurloe/thurloe.tf
+++ b/profiles/thurloe/terraform/thurloe/thurloe.tf
@@ -1,3 +1,6 @@
+data "google_dns_managed_zone" "terra-env-dns-zone" {
+  name = "${var.old_dns_zone}"
+}
 
 # Cloud SQL database
 module "cloudsql" {
@@ -18,8 +21,9 @@ module "cloudsql" {
 }
 
 # Cloud SQL dns
-resource "google_dns_record_set" "mysql-instance" {
+resource "google_dns_record_set" "mysql-instance-old" {
   provider     = "google"
+  count = 0
   managed_zone = "${data.google_dns_managed_zone.terra-env-dns-zone.name}"
   name         = "${var.owner}-${var.service}-mysql.${data.google_dns_managed_zone.terra-env-dns-zone.dns_name}"
   type         = "A"
@@ -75,9 +79,9 @@ resource "google_storage_bucket_iam_member" "app_config" {
 }
 
 # Instance DNS
-resource "google_dns_record_set" "instance-dns" {
+resource "google_dns_record_set" "instance-dns-old" {
   provider     = "google"
-  count        = "${var.instance_num_hosts}"
+  count = 0
   managed_zone = "${data.google_dns_managed_zone.terra-env-dns-zone.name}"
   name         = "${format("${var.service}-%02d.%s",count.index+1,data.google_dns_managed_zone.terra-env-dns-zone.dns_name)}"
   type         = "A"
@@ -106,8 +110,9 @@ module "load-balancer" {
 }
 
 # Service DNS
-resource "google_dns_record_set" "app-dns" {
+resource "google_dns_record_set" "app-dns-old" {
   provider     = "google"
+  count = 0
   managed_zone = "${data.google_dns_managed_zone.terra-env-dns-zone.name}"
   name         = "${var.service}.${data.google_dns_managed_zone.terra-env-dns-zone.dns_name}"
   type         = "A"

--- a/profiles/thurloe/terraform/thurloe/variables.tf.ctmpl
+++ b/profiles/thurloe/terraform/thurloe/variables.tf.ctmpl
@@ -39,7 +39,7 @@ variable "service" {
 }
 variable "vault_path_prefix" {
   default = "{{env "VAULT_PATH_PREFIX"}}"
-  description = "The name of the service within the profile"
+  description = "The path to this profile's secrets in vault"
 }
 
 #
@@ -51,11 +51,9 @@ variable "google_dns_zone" {
 }
 variable "dns_project" {
   default = "{{if (env "TERRA_DNS_PROJECT")}}{{env "TERRA_DNS_PROJECT"}}{{else}}broad-dsde-perf{{end}}"
-  default = "{{env "DNS_ZONE_NAME"}}"
 }
 variable "dns_region" {
   default = "{{if (env "TERRA_DNS_REGION")}}{{env "TERRA_DNS_REGION"}}{{else}}us-central1{{end}}"
-  default = "{{env "DNS_ZONE_NAME"}}"
 }
 # SSL
 variable "google_compute_ssl_certificate_red" {

--- a/profiles/thurloe/terraform/thurloe/variables.tf.ctmpl
+++ b/profiles/thurloe/terraform/thurloe/variables.tf.ctmpl
@@ -59,10 +59,15 @@ variable "service" {
 #
 # DNS
 variable "google_dns_zone" {
-  default = "{{env "OWNER"}}-terra-dns"
+  default = "{{env "DNS_ZONE_NAME"}}"
 }
-data "google_dns_managed_zone" "terra-env-dns-zone" {
-  name = "${var.google_dns_zone}"
+variable "dns_project" {
+  default = "{{if (env "TERRA_DNS_PROJECT")}}{{env "TERRA_DNS_PROJECT"}}{{else}}broad-dsde-perf{{end}}"
+  default = "{{env "DNS_ZONE_NAME"}}"
+}
+variable "dns_region" {
+  default = "{{if (env "TERRA_DNS_REGION")}}{{env "TERRA_DNS_REGION"}}{{else}}us-central1{{end}}"
+  default = "{{env "DNS_ZONE_NAME"}}"
 }
 # SSL
 variable "google_compute_ssl_certificate_red" {
@@ -156,6 +161,15 @@ variable "mysql_instance_dns_cname_record_service_hostname" {
 variable "mysql_instance_dns_cname_record_target_hostname" {
   default = ""
   description = "DNS CNAME record target hostname for default thurloe mysql instance in an env. Should be set as a vault env override for each env."
+}
+
+variable "config_dns_domain" {
+  description = "to use in config rendering"
+  default = "{{if env "CONFIG_DNS_DOMAIN"}}{{env "CONFIG_DNS_DOMAIN"}}{{else}}dsde-perf-broad{{end}}"
+}
+
+variable "old_dns_zone" {
+  default = "{{env "OWNER"}}-terra-dns"
 }
 
 #

--- a/profiles/thurloe/terraform/thurloe/variables.tf.ctmpl
+++ b/profiles/thurloe/terraform/thurloe/variables.tf.ctmpl
@@ -25,22 +25,6 @@ variable "dns_zone_name" {
   default = "{{env "DNS_ZONE_NAME"}}"
   description = "The name of the DNS zone (its google id) as specified in the application json"
 }
-variable "latest_k8s_master_version" {
-  default = "{{env "LATEST_K8S_MASTER_VERSION"}}"
-  description = "A dynamically looked up most recent available gke version"
-}
-variable "latest_k8s_node_version" {
-  default = "{{env "LATEST_K8S_NODE_VERSION"}}"
-  description = "A dynamically looked up most recent available gke version"
-}
-variable "cluster_name" {
-  default = "{{env "CLUSTER_NAME"}}"
-  description = "The name of the cluster in GKE as specified in the application json"
-}
-variable "kubectl_context" {
-  default = "{{env "KUBECTL_CONTEXT"}}"
-  description = "Either the value of `.clusters.default.context` in application json or the standard GKE kubectl context for `GOOGLE_PROJECT`, `GOOGLE_ZONE`, and `CLUSTER_NAME`"
-}
 variable "owner" {
   default = "{{env "OWNER"}}"
   description = "The owner from the application json"
@@ -51,6 +35,10 @@ variable "application_name" {
 }
 variable "service" {
   default = "{{env "SERVICE"}}"
+  description = "The name of the service within the profile"
+}
+variable "vault_path_prefix" {
+  default = "{{env "VAULT_PATH_PREFIX"}}"
   description = "The name of the service within the profile"
 }
 
@@ -96,7 +84,6 @@ variable "config_reader_service_account" {
 data "google_service_account" "config_reader" {
   account_id = "${var.config_reader_service_account}"
 }
-
 
 #
 # Thurloe - Common Vars

--- a/profiles/thurloe/terraform/thurloe/vault.tf
+++ b/profiles/thurloe/terraform/thurloe/vault.tf
@@ -1,6 +1,5 @@
 provider vault {}
 
-# this token will get saved in the state file, which is why a low-scope, time-limited token (and not the user's token) is appropriate.
 resource "vault_generic_secret" "database-credentials" {
   path = "secret/dsde/firecloud/ephemeral/${var.environment}/thurloe/secrets/app_sql_user"
 

--- a/profiles/thurloe/terraform/thurloe/vault.tf
+++ b/profiles/thurloe/terraform/thurloe/vault.tf
@@ -1,0 +1,13 @@
+provider vault {}
+
+# this token will get saved in the state file, which is why a low-scope, time-limited token (and not the user's token) is appropriate.
+resource "vault_generic_secret" "database-credentials" {
+  path = "secret/dsde/firecloud/ephemeral/${var.environment}/thurloe/secrets/app_sql_user"
+
+  data_json = <<EOT
+{
+  "username": "${var.cloudsql_app_username}",
+  "password": "${var.cloudsql_app_password}"
+}
+EOT
+}


### PR DESCRIPTION
This proposes a way of populating Vault with secrets from two sources:

1) The created terraform environment
2) Existing Vault secrets (copying)

The goal here is that over time, more secrets will come from #1 and fewer from #2. Copying exists so that we can use values manually populated in Vault when we create ephemeral environments, and still let the configs for each environment get populated from an environment-specific vault path prefix (see https://github.com/broadinstitute/firecloud-develop/pull/1698).

This approach has security implications. Specifically, secrets read or populated with terraform are stored in the terraform state file in cleartext (https://www.terraform.io/docs/providers/vault/index.html). This could be helpful since it allows terraform to keep the values for an environment up to date, but it obviously means that terraform state files get a lot more sensitive.

One alternative that would function equivalently but _not_ store data in tf state would be to use a `null_resource` plus a script ( similar to https://github.com/broadinstitute/terraform-terra/blob/master/profiles/thurloe-configs/terraform/thurloe/config.tf#L11 ) and a list of `{copy_from: xxx, copy_to:xxx}` variables. This would prevent the terraform state from knowing about the vault values at all, but would likely require repopulating all secrets (or an equivalent amount of work) every time.