### PR TITLE
set consul-template log level and retry attempts

### DIFF
--- a/broad-wb-malkov.json
+++ b/broad-wb-malkov.json
@@ -1,7 +1,7 @@
 {
   "name": "terra",
   "owner": "gmalkov",
-  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:rl_1",
+  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:48229e65030",
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",

--- a/broad-wb-perf2.json
+++ b/broad-wb-perf2.json
@@ -1,7 +1,7 @@
 {
   "name": "terra",
   "owner": "broad-wb-perf2",
-  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:rl_5",
+  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:48229e65030",
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",

--- a/broad-wb-perf2.json
+++ b/broad-wb-perf2.json
@@ -1,7 +1,7 @@
 {
   "name": "terra",
   "owner": "broad-wb-perf2",
-  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:92b53bdf2d82e5",
+  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:rl_5",
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",
@@ -19,7 +19,8 @@
         "APP_NAME": "thurloe",
         "FIRECLOUD_DEVELOP_GIT_BRANCH": "dev",
         "SERVICE_GIT_SHA_12_CHAR": "4c11a7177674"
-      }
+      },
+      "consul_template": {"log_level": "debug"}
     },
     "opendj-configs": {
       "env": {

--- a/broad-wb-rluckom.json
+++ b/broad-wb-rluckom.json
@@ -1,7 +1,7 @@
 {
   "name": "terra",
   "owner": "broad-wb-rluckom",
-  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:rl_1",
+  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:rl_5",
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",
@@ -11,7 +11,8 @@
     },
     "vault": {
       "policy": "dsde-write"
-    }
+    },
+    "consul_template": {"log_level": "debug"}
   },
   "profile_vars": {
     "thurloe-configs": {

--- a/broad-wb-rluckom.json
+++ b/broad-wb-rluckom.json
@@ -1,7 +1,7 @@
 {
   "name": "terra",
   "owner": "broad-wb-rluckom",
-  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:rl_5",
+  "terraform_image": "us.gcr.io/broad-dsp-gcr-public/config-render:48229e65030",
   "intent": "terra infrastructure",
   "production": false,
   "stability": "volatile",

--- a/containers/ruby-consul-terraform/render_configs.rb
+++ b/containers/ruby-consul-terraform/render_configs.rb
@@ -88,6 +88,7 @@ if __FILE__ == $0
   # container and override the `render_ctmpl` function with one that uses
   # consul-template locally.
   def render_ctmpl(file_name, output_file_name, tmp_dir=nil)
+    consul_log_level = ENV.fetch("CONSUL_LOG_LEVEL", "err")
     if tmp_dir.nil?
       tmp_dir = (Dir.pwd.split("/") - $base_dir.split("/")) * "/"
     end
@@ -118,10 +119,14 @@ if __FILE__ == $0
       cmd_env, 
       "consul-template", 
       "-config=#{$vault_config_path}", 
+      "-log-level=#{consul_log_level}",
+      "-vault-retry-attempts=3",
       "-template=/data/configs/#{$instance_name}/#{tmp_dir}/#{file_name}:/data/configs/#{$instance_name}/#{tmp_dir}/#{output_file_name}",
       "-once"
     ) { |stdin, stdout, stderr, wait_thread|
     if wait_thread.value.success?
+      puts stdout.read
+      puts stderr.read
       puts "#{file_name} > #{output_file_name}"
       File.delete(file_name)
     else

--- a/profiles/thurloe-configs/terraform/thurloe/config.tf
+++ b/profiles/thurloe-configs/terraform/thurloe/config.tf
@@ -15,6 +15,7 @@ resource "null_resource" "config" {
   provisioner "local-exec" {
     command = "ruby /workbench/render_configs.rb"
     environment = {
+      CONSUL_LOG_LEVEL = "${var.consul_log_level}"
       INSTANCES = "${jsonencode(data.google_compute_instance_group.service-instances.instances)}"
       CONFIG_BUCKET = "${var.config_bucket_name}"
       VAULT_TOKEN = "${vault_token.render_token.client_token}"

--- a/profiles/thurloe-configs/terraform/thurloe/variables.tf.ctmpl
+++ b/profiles/thurloe-configs/terraform/thurloe/variables.tf.ctmpl
@@ -132,3 +132,7 @@ variable "bucket_tag" {
   description = "to use in config rendering"
   default = "{{if env "BUCKET_TAG"}}{{env "BUCKET_TAG"}}{{else}}{{env "ENVIRONMENT"}}{{end}}"
 }
+
+variable "consul_log_level" {
+  default = "{{if env "LOG_LEVEL"}}{{env "LOG_LEVEL"}}{{else}}err{{end}}"
+}


### PR DESCRIPTION
This uses https://github.com/broadinstitute/dsp-k8s-deploy/pull/27 to add configurable consul logging to the Thurloe template rendering step. 

I'm not adding this in sam and opendj in this PR because there's an open PR for thoseand I don't want to cause conflicts.