### PR TITLE
Permissions update

### DIFF
--- a/profiles/vm-image-sa/terraform/vm-image-sa/sa.tf
+++ b/profiles/vm-image-sa/terraform/vm-image-sa/sa.tf
@@ -17,6 +17,6 @@ resource "google_service_account_key" "app_account_key" {
 provider "vault" {}
 
 resource "vault_generic_secret" "app_account_key" {
-  path = "secret/dsde/firecloud/common/${var.account_name}-account.json"
+  path = "secret/dsde/firecloud/common/${var.account_name}.json"
   data_json = "${base64decode(google_service_account_key.app_account_key.private_key)}"
 }

--- a/profiles/vm-image-sa/terraform/vm-image-sa/variables.tf.ctmpl
+++ b/profiles/vm-image-sa/terraform/vm-image-sa/variables.tf.ctmpl
@@ -21,5 +21,6 @@ variable "sa_roles" {
   default = [
     "roles/compute.admin",
     "roles/iam.serviceAccountUser",
+    "roles/storage.objectViewer",
   ]
 }

--- a/profiles/vm-image-sa/terraform/vm-image-sa/variables.tf.ctmpl
+++ b/profiles/vm-image-sa/terraform/vm-image-sa/variables.tf.ctmpl
@@ -20,5 +20,6 @@ variable "sa_roles" {
   type = "list"
   default = [
     "roles/compute.admin",
+    "roles/iam.serviceAccountUser",
   ]
 }


### PR DESCRIPTION
the script needs these permissions as it tries to create an instance with a service account for testing the custom image

```
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - The user does not have access to service account '1028065715937-compute@developer.gserviceaccount.com'.  User: 'image-build-account@broad-dsp-gcr-public.iam.gserviceaccount.com'.  Ask a project owner to grant you the iam.serviceAccountUser role on the service account
```