### PR TITLE
adding permission needed for smoke test

### DIFF
--- a/profiles/vm-image-sa/terraform/vm-image-sa/variables.tf.ctmpl
+++ b/profiles/vm-image-sa/terraform/vm-image-sa/variables.tf.ctmpl
@@ -22,5 +22,6 @@ variable "sa_roles" {
     "roles/compute.admin",
     "roles/iam.serviceAccountUser",
     "roles/storage.objectViewer",
+    "roles/dataproc.editor",
   ]
 }


### PR DESCRIPTION
This permission is needed as the script creates a custom dataproc image, which it then uses to spin up a dataproc cluster for testing purposes. 