### PR TITLE
Add Rawls VPC-SC Terraform profile

### DIFF
--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/ingress-bridges.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/ingress-bridges.tf
@@ -1,0 +1,41 @@
+# Advanced Rawls VPC-SC configuration for data ingest. This may only be
+# necessary in certain configurations, depending on data and enforcement needs.
+# See this [design](https://docs.google.com/document/d/1EHw5nisXspJjA9yeZput3W4-vSIcuLBU5dPizTnk1i0/edit) for details.
+
+data "google_project" "ingress_project" {
+  for_each = var.ingress_bridges
+  project_id = each.value.ingress_project_id
+}
+
+data "google_project" "protected_project" {
+  for_each = var.ingress_bridges
+  project_id = each.value.protected_project_id
+}
+
+resource "google_access_context_manager_service_perimeter" "ingress-bridge" {
+  for_each = var.ingress_bridges
+
+  parent      = "accessPolicies/${var.access_policy_name}"
+  name        = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}_ingress_bridge"
+  title       = "${each.key}_ingress_bridge"
+  perimeter_type = "PERIMETER_TYPE_BRIDGE"
+  status {
+    resources = [
+      "projects/${data.google_project.ingress_project[each.key].number}",
+      "projects/${data.google_project.protected_project[each.key].number}"
+    ]
+  }
+}
+
+resource "google_access_context_manager_service_perimeter" "ingress-perimeter" {
+  for_each = var.ingress_bridges
+
+  parent      = "accessPolicies/${var.access_policy_name}"
+  name        = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}_ingress"
+  title       = "${each.key}_ingress"
+  status {
+    resources = ["projects/${data.google_project.ingress_project[each.key].number}"]
+    # Unrestricted, to allow for ingress.
+    restricted_services = []
+  }
+}

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/ingress-bridges.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/ingress-bridges.tf
@@ -3,21 +3,21 @@
 # See this [design](https://docs.google.com/document/d/1EHw5nisXspJjA9yeZput3W4-vSIcuLBU5dPizTnk1i0/edit) for details.
 
 data "google_project" "ingress_project" {
-  for_each = var.ingress_bridges
+  for_each   = var.ingress_bridges
   project_id = each.value.ingress_project_id
 }
 
 data "google_project" "protected_project" {
-  for_each = var.ingress_bridges
+  for_each   = var.ingress_bridges
   project_id = each.value.protected_project_id
 }
 
 resource "google_access_context_manager_service_perimeter" "ingress-bridge" {
   for_each = var.ingress_bridges
 
-  parent      = "accessPolicies/${var.access_policy_name}"
-  name        = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}_ingress_bridge"
-  title       = "${each.key}_ingress_bridge"
+  parent         = "accessPolicies/${var.access_policy_name}"
+  name           = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}_ingress_bridge"
+  title          = "${each.key}_ingress_bridge"
   perimeter_type = "PERIMETER_TYPE_BRIDGE"
   status {
     resources = [
@@ -30,9 +30,9 @@ resource "google_access_context_manager_service_perimeter" "ingress-bridge" {
 resource "google_access_context_manager_service_perimeter" "ingress-perimeter" {
   for_each = var.ingress_bridges
 
-  parent      = "accessPolicies/${var.access_policy_name}"
-  name        = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}_ingress"
-  title       = "${each.key}_ingress"
+  parent = "accessPolicies/${var.access_policy_name}"
+  name   = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}_ingress"
+  title  = "${each.key}_ingress"
   status {
     resources = ["projects/${data.google_project.ingress_project[each.key].number}"]
     # Unrestricted, to allow for ingress.

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
@@ -1,0 +1,50 @@
+data "google_organization" "org" {
+  domain = var.org_domain
+}
+
+# Standard Rawls VPC-SC configuration:
+#  - A folder to track all billing projects within the perimeter.
+#  - A managed perimeter with corresponding accessLevels whitelist.
+resource "google_folder" "folder" {
+  for_each = var.perimeters
+
+  parent = "organizations/${data.google_organization.org.id}"
+  display_name = each.key
+}
+
+resource "google_access_context_manager_access_level" "access-level" {
+  for_each = var.perimeters
+
+  parent      = "accessPolicies/${var.access_policy_name}"
+  name        = "accessPolicies/${var.access_policy_name}/accessLevels/${each.key}"
+  title       = each.key
+  basic {
+    conditions {
+      members = each.value.access_member_whitelist
+    }
+  }
+}
+
+resource "google_access_context_manager_service_perimeter" "service-perimeter" {
+  for_each = var.perimeters
+
+  parent      = "accessPolicies/${var.access_policy_name}"
+  name        = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}"
+  title       = each.key
+  status {
+    resources = []
+    restricted_services = each.value.restricted_services
+    access_levels = [
+      google_access_context_manager_access_level.access-level[each.key].name
+    ]
+  }
+  lifecycle {
+    ignore_changes = [
+      # Projects in this perimeter are managed by Rawls, as billing projects are
+      # dynamically added/removed from the perimeter. Ideally we would just
+      # ignore status["resources"], but ignoring at this granularity is
+      # unsupported. https://github.com/terraform-providers/terraform-provider-google/issues/4509
+      status
+    ]
+  }
+}

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
@@ -8,16 +8,16 @@ data "google_organization" "org" {
 resource "google_folder" "folder" {
   for_each = var.perimeters
 
-  parent = "organizations/${data.google_organization.org.id}"
+  parent       = "organizations/${data.google_organization.org.id}"
   display_name = each.key
 }
 
 resource "google_access_context_manager_access_level" "access-level" {
   for_each = var.perimeters
 
-  parent      = "accessPolicies/${var.access_policy_name}"
-  name        = "accessPolicies/${var.access_policy_name}/accessLevels/${each.key}"
-  title       = each.key
+  parent = "accessPolicies/${var.access_policy_name}"
+  name   = "accessPolicies/${var.access_policy_name}/accessLevels/${each.key}"
+  title  = each.key
   basic {
     conditions {
       members = each.value.access_member_whitelist
@@ -28,11 +28,11 @@ resource "google_access_context_manager_access_level" "access-level" {
 resource "google_access_context_manager_service_perimeter" "service-perimeter" {
   for_each = var.perimeters
 
-  parent      = "accessPolicies/${var.access_policy_name}"
-  name        = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}"
-  title       = each.key
+  parent = "accessPolicies/${var.access_policy_name}"
+  name   = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}"
+  title  = each.key
   status {
-    resources = []
+    resources           = []
     restricted_services = each.value.restricted_services
     access_levels = [
       google_access_context_manager_access_level.access-level[each.key].name

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -1,0 +1,22 @@
+variable "org_domain" {
+  type    = string
+  description = "GCP organization domain name to contain this perimeter and folder"
+  default = "{{env "ORGANIZATION_DOMAIN"}}"
+}
+
+variable "access_policy_name" {
+  type    = string
+  description = "Resource name of existing access context manager policy to create perimeters within"
+    access_member_whitelist = list(string)
+}))
+  default = [
+    {{ with $profile_json := env "PROFILE_JSON_PATH" | file | parseJSON }}
+      {{ range index $profile_json "profile_vars" "rawls-service-perimeters" "extras" "perimeters" }}
+        name = "{{ .name }}"
+        restricted_services = {{ printf "%q" .restricted_services }}
+        access_member_whitelist = {{ printf "%q" .access_member_whitelist }}
+      {{ end }}
+    {{ end }}
+  ]
+}
+

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -1,22 +1,49 @@
 variable "org_domain" {
   type    = string
   description = "GCP organization domain name to contain this perimeter and folder"
-  default = "{{env "ORGANIZATION_DOMAIN"}}"
+  # default = "{{env "ORGANIZATION_DOMAIN"}}"
+  default = "test.firecloud.org"
 }
 
 variable "access_policy_name" {
   type    = string
   description = "Resource name of existing access context manager policy to create perimeters within"
-    access_member_whitelist = list(string)
-}))
-  default = [
-    {{ with $profile_json := env "PROFILE_JSON_PATH" | file | parseJSON }}
-      {{ range index $profile_json "profile_vars" "rawls-service-perimeters" "extras" "perimeters" }}
-        name = "{{ .name }}"
-        restricted_services = {{ printf "%q" .restricted_services }}
-        access_member_whitelist = {{ printf "%q" .access_member_whitelist }}
-      {{ end }}
-    {{ end }}
-  ]
+  # default = "{{env "ACCESS_POLICY_NAME"}}"
+  default = "228353087260"
 }
 
+{{ define "toJSONStringArray" }}[{{range $i, $v := .}}{{if $i}}, {{end}}{{printf "%q" $v}}{{end}}]{{ end }}
+
+{{ with $profile_json := file "/env.json" | parseJSON }}
+{{ $perimeters := index $profile_json "profile_vars" "rawls-service-perimeters" "extras" "perimeters" }}
+
+variable "perimeters" {
+  type    = map(object({
+    restricted_services = list(string)
+    access_member_whitelist = list(string)
+  }))
+  default = {
+    {{ range $k, $v := $perimeters }}
+    "{{ $k }}" = {
+      restricted_services = {{ template "toJSONStringArray" $v.restricted_services }}
+      access_member_whitelist = {{ template "toJSONStringArray" $v.access_member_whitelist }}
+    }
+    {{ end }}
+  }
+}
+
+variable "ingress_bridges" {
+  type    = map(object({
+    ingress_project_id = string
+    protected_project_id = string
+  }))
+  default = {
+    {{ range $k, $v := $perimeters }}{{ if $v.ingress_bridge }}
+    "{{ $k }}" = {
+      ingress_project_id = "{{ $v.ingress_bridge.ingress_project_id }}"
+      protected_project_id = "{{ $v.ingress_bridge.protected_project_id }}"
+    }
+    {{ end }}{{ end }}
+  }
+}
+{{end}}

--- a/terra-rawls-vpc-dev.json
+++ b/terra-rawls-vpc-dev.json
@@ -14,7 +14,7 @@
       "providers": {
         "google": {
           "default": {
-            "project": "terra-arrow-perf",
+            "project": "TODO",
             "vault_sa_path": "TODO",
             "region": "us-central1"
           }
@@ -34,15 +34,20 @@
         "ACCESS_POLICY_NAME": "228353087260"
       },
       "extras": {
-        "perimeters": [{
-          "name": "terra_dev_aou_dev",
-          "restricted_services": ["bigquery.googleapis.com"],
-          "access_member_whitelist": [
-            "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
-            "serviceAccount:leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com",
-            "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com"
-          ]
-        }]
+        "perimeters": {
+          "terra_dev_aou_dev": {
+            "restricted_services": ["bigquery.googleapis.com"],
+            "access_member_whitelist": [
+              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
+              "serviceAccount:leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com",
+              "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com"
+            ],
+            "ingress_bridge": {
+              "ingress_project_id": "fc-aou-cdr-ingest-synth-test",
+              "protected_project_id": "fc-aou-cdr-synth-test"
+            }
+          }
+        }
       }
     }
   }

--- a/terra-rawls-vpc-dev.json
+++ b/terra-rawls-vpc-dev.json
@@ -1,0 +1,49 @@
+{
+  "name": "terra-rawls-vpc-dev",
+  "owner": "terra-dev",
+  "intent": "terra infrastructure",
+  "production": false,
+  "stability": "volatile",
+  "environment": "dev",
+  "global_vars": {
+    "vault": {
+      "policy": "dsde-write"
+    },
+    "terraform": {
+      "docker_image": "us.gcr.io/broad-dsp-gcr-public/config-render:7c6c57f6",
+      "providers": {
+        "google": {
+          "default": {
+            "project": "terra-arrow-perf",
+            "vault_sa_path": "TODO",
+            "region": "us-central1"
+          }
+        }
+      },
+      "backend": {
+        "vault_sa_path": "TODO",
+        "state_path_prefix":"terra",
+        "state_bucket": "broad-dsp-terraform-state"
+      }
+    }
+  },
+  "profile_vars": {
+    "rawls-service-perimeters": {
+      "env": {
+        "ORGANIZATION_DOMAIN": "test.firecloud.org",
+        "ACCESS_POLICY_NAME": "228353087260"
+      },
+      "extras": {
+        "perimeters": [{
+          "name": "terra_dev_aou_dev",
+          "restricted_services": ["bigquery.googleapis.com"],
+          "access_member_whitelist": [
+            "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
+            "serviceAccount:leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com",
+            "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com"
+          ]
+        }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
For ease of management, this effort requires that we instantiate multiple perimeters with a single profile environment, to match the logical ownership of one rawls server environment to a set of associated perimeter configurations. To achieve this required some gymnastics in the profile templating tools to allow for more complex input types - here arbitrary JSON is supported.

Idea:
- copy or mount the profile.json file onto the rendering docker image 
- Define arbitrary "extras" section in a given profile configuration
- Read this directly in consul template, pull out arbitrary structured JSON values

TODO: volume mounting, other environments, complete environment config, test e2e with rendering

Current testing approach for the consul rendering:
```
docker run -v $(pwd)/terra-rawls-vpc-dev.json:/env.json -v $(pwd)/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl:/in.tpl -v $(pwd)/out:/out hashicorp/consul-template -template "/in.tpl:/out/vars.tf" -once && cat out/vars.tf
```