### PR TITLE
Bring in all existing perimeters

### DIFF
--- a/terra-rawls-vpc-dev.json
+++ b/terra-rawls-vpc-dev.json
@@ -14,7 +14,7 @@
       "providers": {
         "google": {
           "default": {
-            "project": "calbach-test-project",
+            "project": "TODO",
             "vault_sa_path": "secret/dsde/firecloud/common/test-fc-org-perimeters-service-account.json",
             "region": "us-central1"
           }
@@ -46,6 +46,13 @@
               "ingress_project_id": "fc-aou-vpc-ingest-test",
               "protected_project_id": "fc-aou-cdr-synth-test"
             }
+          },
+          "terra_dev_baseline_test": {
+            "restricted_services": ["bigquery.googleapis.com"],
+            "access_member_whitelist": [
+              "user:dvoettest@gmail.com",
+              "serviceAccount:leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com"
+            ]
           }
         }
       }

--- a/terra-rawls-vpc-perf.json
+++ b/terra-rawls-vpc-perf.json
@@ -1,0 +1,49 @@
+{
+  "name": "terra-rawls-vpc-perf",
+  "owner": "TODO",
+  "intent": "terra infrastructure",
+  "production": false,
+  "stability": "volatile",
+  "environment": "TODO",
+  "global_vars": {
+    "vault": {
+      "policy": "dsde-write"
+    },
+    "terraform": {
+      "docker_image": "us.gcr.io/broad-dsp-gcr-public/config-render:eb15b5a3",
+      "providers": {
+        "google": {
+          "default": {
+            "project": "TODO",
+            "vault_sa_path": "TODO",
+            "region": "us-central1"
+          }
+        }
+      },
+      "backend": {
+        "vault_sa_path": "TODO",
+        "state_path_prefix":"TODO?",
+        "state_bucket": "broad-dsp-terraform-state"
+      }
+    }
+  },
+  "profile_vars": {
+    "rawls-service-perimeters": {
+      "env": {
+        "ORGANIZATION_DOMAIN": "test.firecloud.org",
+        "ACCESS_POLICY_NAME": "228353087260"
+      },
+      "extras": {
+        "perimeters": {
+          "terra_perf_aou_perf": {
+            "restricted_services": ["bigquery.googleapis.com"],
+            "access_member_whitelist": [
+              "serviceAccount:all-of-us-rw-perf@appspot.gserviceaccount.com",
+              "serviceAccount:leonardo-perf@broad-dsde-perf.iam.gserviceaccount.com"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/terra-rawls-vpc-prod.json
+++ b/terra-rawls-vpc-prod.json
@@ -1,0 +1,77 @@
+{
+  "name": "terra-rawls-vpc-prod",
+  "owner": "TODO",
+  "intent": "terra infrastructure",
+  "production": false,
+  "stability": "volatile",
+  "environment": "TODO",
+  "global_vars": {
+    "vault": {
+      "policy": "dsde-write"
+    },
+    "terraform": {
+      "docker_image": "us.gcr.io/broad-dsp-gcr-public/config-render:eb15b5a3",
+      "providers": {
+        "google": {
+          "default": {
+            "project": "TODO",
+            "vault_sa_path": "TODO",
+            "region": "us-central1"
+          }
+        }
+      },
+      "backend": {
+        "vault_sa_path": "TODO",
+        "state_path_prefix":"TODO?",
+        "state_bucket": "broad-dsp-terraform-state"
+      }
+    }
+  },
+  "profile_vars": {
+    "rawls-service-perimeters": {
+      "env": {
+        "ORGANIZATION_DOMAIN": "firecloud.org",
+        "ACCESS_POLICY_NAME": "357236995176"
+      },
+      "extras": {
+        "perimeters": {
+          "terra_prod_aou_prod": {
+            "restricted_services": ["bigquery.googleapis.com"],
+            "access_member_whitelist": [
+              "serviceAccount:all-of-us-rw-prod@appspot.gserviceaccount.com",
+              "serviceAccount:leonardo-prod@broad-dsde-prod.iam.gserviceaccount.com",
+              "serviceAccount:deploy@all-of-us-rw-prod.iam.gserviceaccount.com"
+            ]
+          },
+          "terra_prod_aou_stable": {
+            "restricted_services": ["bigquery.googleapis.com"],
+            "access_member_whitelist": [
+              "serviceAccount:all-of-us-rw-stable@appspot.gserviceaccount.com",
+              "serviceAccount:leonardo-prod@broad-dsde-prod.iam.gserviceaccount.com",
+              "serviceAccount:deploy@all-of-us-rw-stable.iam.gserviceaccount.com"
+            ]
+          },
+          "terra_prod_aou_staging": {
+            "restricted_services": ["bigquery.googleapis.com"],
+            "access_member_whitelist": [
+              "serviceAccount:all-of-us-rw-staging@appspot.gserviceaccount.com",
+              "serviceAccount:leonardo-prod@broad-dsde-prod.iam.gserviceaccount.com",
+              "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com"
+            ]
+          },
+          "terra_prod_baseline_prod": {
+            "restricted_services": ["bigquery.googleapis.com"],
+            "access_member_whitelist": [
+              "serviceAccount:leonardo-prod@broad-dsde-prod.iam.gserviceaccount.com",
+              "user:melchang@google.com",
+              "user:seanhorgan@google.com",
+              "user:willyn@google.com",
+              "serviceAccount:indexer@baseline-explorer.iam.gserviceaccount.com",
+              "serviceAccount:rawls-prod@broad-dsde-prod.iam.gserviceaccount.com"
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
If correctly imported, this should produce 0 diffs.

Related issues:
1. placeholder accessLevels are defined across other Terra envs (alpha, staging, qa), but appear to be unused. I don't know whether it's worth porting those into this repo before they are used: https://github.com/broadinstitute/firecloud-develop/tree/dev/run-context/live/scripts/service-perimeters/access-levels/alpha
2. There is some additional scripting in firecloud-devop for initializing a perimeter in Sam. This will need to be ported into the new approach somehow.

New perimeters/bridges are separated out into this PR: https://github.com/calbach/terraform-terra/pull/1

@gpolumbo-broad @RLuckom 