### PR TITLE
Enable AoU GCS exfiltration enforcement in dev

### DIFF
--- a/terra-dev.json
+++ b/terra-dev.json
@@ -68,7 +68,10 @@
       "extras": {
         "perimeters": {
           "terra_dev_aou_test": {
-            "restricted_services": ["bigquery.googleapis.com"],
+            "restricted_services": [
+              "bigquery.googleapis.com",
+              "storage.googleapis.com"
+            ],
             "access_member_whitelist": [
               "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
               "serviceAccount:leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com",


### PR DESCRIPTION
No action required - I've already applied this update in dev with my test Firecloud admin account:

```
gcloud access-context-manager perimeters update accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test --add-restricted-services=storage.googleapis.com
```

~~Note: manual gcloud commands are necessary to update this on account of https://github.com/terraform-providers/terraform-provider-google/issues/4509~~

**Update**: https://github.com/broadinstitute/terraform-terra/pull/117 fixes this so the change can be applied with a normal terraform apply.

Expect follow-up PR(s) next week to apply a similar change in the other environments (I will need help applying those).