### PR TITLE
Use a more specific ignore_changes filter on perimeters

### DIFF
--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
@@ -41,10 +41,8 @@ resource "google_access_context_manager_service_perimeter" "service-perimeter" {
   lifecycle {
     ignore_changes = [
       # Projects in this perimeter are managed by Rawls, as billing projects are
-      # dynamically added/removed from the perimeter. Ideally we would just
-      # ignore status["resources"], but ignoring at this granularity is
-      # unsupported. https://github.com/terraform-providers/terraform-provider-google/issues/4509
-      status
+      # dynamically added/removed from the perimeter.
+      status[0].resources
     ]
   }
 }


### PR DESCRIPTION
This eliminates one of the key caveats of the Terraform setup: You can now apply changes to the restricted services list via a normal Terraform update.

Per my old comment here, turns out this wasn't an issue with the Terraform provider; I just didn't have the right syntax. I was educated here: https://github.com/terraform-providers/terraform-provider-google/issues/4509 . Previously, this filter ignored the whole `status` field, which unnecessarily included `restricted_services` and `access_levels` - this meant you could only use Terraform for the initial creation but not subsequent updates to set these particular fields.