### PR TITLE
Add IAM admin policies for AoU Rawls folders

### DIFF
--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
@@ -12,6 +12,40 @@ resource "google_folder" "folder" {
   display_name = each.key
 }
 
+# Perimeter folder admins are users with direct administrative access to the
+# folder. For example, in All of Us, the primary service account uses these
+# roles to perform administrative tasks on workspaces, such as associating the
+# free tier billing account, renaming files, or checking Stackdriver egress
+# metrics.
+#
+# This is useful when administrative accounts are not owners of the workspaces
+# in their perimeter, or when they own too many workspaces and normal Google
+# Group access via Sam no longer functions:
+# https://docs.google.com/document/d/1-nc7hwqhM-pdJlsR-41u7zgy43kEKf8tptGhTuwbgUk/edit
+resource "google_folder_iam_policy" "folder-admin-policy" {
+  for_each = var.folder_admins
+
+  folder      = google_folder.folder[each.key].name
+  policy_data = data.google_iam_policy.perimeter-policy[each.key].policy_data
+}
+
+data "google_iam_policy" "perimeter-policy" {
+  for_each = var.folder_admins
+
+  binding {
+    role = "organizations/${data.google_organization.org.id}/roles/terraBucketWriter"
+    members = each.value.members
+  }
+  binding {
+    role = "roles/billing.projectManager"
+    members = each.value.members
+  }
+  binding {
+    role = "roles/monitoring.viewer"
+    members = each.value.members
+  }
+}
+
 resource "google_access_context_manager_access_level" "access-level" {
   for_each = var.perimeters
 

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -37,6 +37,23 @@ variable "perimeters" {
   }
 }
 
+# Sparse map of perimeter folder admins. Only contains entries for perimeters
+# which specify a list of admins.
+variable "folder_admins" {
+  type    = map(object({
+    members = list(string)
+  }))
+  default = {
+    {{ range $k, $v := $perimeters }}{{ if $v.folder_admins }}
+    "{{ $k }}" = {
+      members = {{ template "toJSONStringArray" $v.folder_admins }}
+    }
+    {{ end }}{{ end }}
+  }
+}
+
+# Sparse map of ingress bridge configurations. Only contains entries for
+# perimeters which define ingress bridges.
 variable "ingress_bridges" {
   type    = map(object({
     ingress_project_id = string
@@ -51,4 +68,5 @@ variable "ingress_bridges" {
     {{ end }}{{ end }}
   }
 }
+
 {{end}}

--- a/terra-dev.json
+++ b/terra-dev.json
@@ -78,6 +78,9 @@
               "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
               "serviceAccount:806222273987-ksinuueghug8u81i36lq8aof266q19hl@developer.gserviceaccount.com"
             ],
+            "folder_admins": [
+              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com"
+            ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-test",
               "protected_project_id": "fc-aou-cdr-synth-test"

--- a/terra-perf.json
+++ b/terra-perf.json
@@ -74,6 +74,9 @@
               "serviceAccount:all-of-us-rw-perf@appspot.gserviceaccount.com",
               "serviceAccount:leonardo-perf@broad-dsde-perf.iam.gserviceaccount.com",
               "serviceAccount:rawls-perf@broad-dsde-perf.iam.gserviceaccount.com"
+            ],
+            "folder_admins": [
+              "serviceAccount:all-of-us-rw-perf@appspot.gserviceaccount.com"
             ]
           }
         }

--- a/terra-prod.json
+++ b/terra-prod.json
@@ -115,6 +115,9 @@
               "serviceAccount:deploy@all-of-us-rw-prod.iam.gserviceaccount.com",
               "serviceAccount:rawls-prod@broad-dsde-prod.iam.gserviceaccount.com"
             ],
+            "folder_admins": [
+              "serviceAccount:all-of-us-rw-prod@appspot.gserviceaccount.com"
+            ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-prod",
               "protected_project_id": "fc-aou-cdr-prod"
@@ -131,6 +134,9 @@
               "serviceAccount:deploy@all-of-us-rw-stable.iam.gserviceaccount.com",
               "serviceAccount:rawls-prod@broad-dsde-prod.iam.gserviceaccount.com"
             ],
+            "folder_admins": [
+              "serviceAccount:all-of-us-rw-stable@appspot.gserviceaccount.com"
+            ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-stable",
               "protected_project_id": "fc-aou-cdr-synth-stable"
@@ -146,6 +152,9 @@
               "serviceAccount:leonardo-prod@broad-dsde-prod.iam.gserviceaccount.com",
               "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
               "serviceAccount:rawls-prod@broad-dsde-prod.iam.gserviceaccount.com"
+            ],
+            "folder_admins": [
+              "serviceAccount:all-of-us-rw-staging@appspot.gserviceaccount.com"
             ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-staging",


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CA-688
https://broadworkbench.atlassian.net/browse/DDO-111

- Adds a new optional `folder_admins` parameter to a perimeter config, which grants IAM roles on the folder corresponding to a Rawls perimeter
- Functional change: adds the Monitoring Viewer role per CA-688. All other bindings should already exist.
- The folder IAM may need to be imported before this is applied, to verify there are no extra bindings which might be removed by this.

If there are extra IAM bindings that need to be maintained, but which we don't want to manage via this Terraform config, I can change the Terraform to be non-destructive.

Note: I don't have access to render this template or fully execute terraform plan. I used the following command to at least test the Terraform rendering and do some basic validation:
```
docker run -v $(pwd)/terra-dev.json:/env.json -v $(pwd)/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl:/in.tpl -v $(pwd)/out:/out hashicorp/consul-template -template "/in.tpl:/out/vars.tf" -once && cat out/vars.tf
```