### PR TITLE
Temporarily revert GCS enforcement in AoU prod

### DIFF
--- a/terra-prod.json
+++ b/terra-prod.json
@@ -106,8 +106,7 @@
         "perimeters": {
           "terra_prod_aou_prod": {
             "restricted_services": [
-              "bigquery.googleapis.com",
-              "storage.googleapis.com"
+              "bigquery.googleapis.com"
             ],
             "access_member_whitelist": [
               "serviceAccount:all-of-us-rw-prod@appspot.gserviceaccount.com",


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-4431

Background: we sent out communications to ask folks to clone / upgrade their older workspaces before we deleted them all, some of these predate the perimeter and are therefore outside. Cloning now understandably fails when attempting to copy workspace notebooks into the perimeter.

Plan is revert GCS enforcement for a week while we give folks a chance to clone, then re-enable.