### PR TITLE
Revert "Add IAM admin policies for AoU Rawls folders"

### DIFF
--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
@@ -12,40 +12,6 @@ resource "google_folder" "folder" {
   display_name = each.key
 }
 
-# Perimeter folder admins are users with direct administrative access to the
-# folder. For example, in All of Us, the primary service account uses these
-# roles to perform administrative tasks on workspaces, such as associating the
-# free tier billing account, renaming files, or checking Stackdriver egress
-# metrics.
-#
-# This is useful when administrative accounts are not owners of the workspaces
-# in their perimeter, or when they own too many workspaces and normal Google
-# Group access via Sam no longer functions:
-# https://docs.google.com/document/d/1-nc7hwqhM-pdJlsR-41u7zgy43kEKf8tptGhTuwbgUk/edit
-resource "google_folder_iam_policy" "folder-admin-policy" {
-  for_each = var.folder_admins
-
-  folder      = google_folder.folder[each.key].name
-  policy_data = data.google_iam_policy.perimeter-policy[each.key].policy_data
-}
-
-data "google_iam_policy" "perimeter-policy" {
-  for_each = var.folder_admins
-
-  binding {
-    role = "organizations/${data.google_organization.org.id}/roles/terraBucketWriter"
-    members = each.value.members
-  }
-  binding {
-    role = "roles/billing.projectManager"
-    members = each.value.members
-  }
-  binding {
-    role = "roles/monitoring.viewer"
-    members = each.value.members
-  }
-}
-
 resource "google_access_context_manager_access_level" "access-level" {
   for_each = var.perimeters
 

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -37,23 +37,6 @@ variable "perimeters" {
   }
 }
 
-# Sparse map of perimeter folder admins. Only contains entries for perimeters
-# which specify a list of admins.
-variable "folder_admins" {
-  type    = map(object({
-    members = list(string)
-  }))
-  default = {
-    {{ range $k, $v := $perimeters }}{{ if $v.folder_admins }}
-    "{{ $k }}" = {
-      members = {{ template "toJSONStringArray" $v.folder_admins }}
-    }
-    {{ end }}{{ end }}
-  }
-}
-
-# Sparse map of ingress bridge configurations. Only contains entries for
-# perimeters which define ingress bridges.
 variable "ingress_bridges" {
   type    = map(object({
     ingress_project_id = string
@@ -68,5 +51,4 @@ variable "ingress_bridges" {
     {{ end }}{{ end }}
   }
 }
-
 {{end}}

--- a/terra-dev.json
+++ b/terra-dev.json
@@ -78,9 +78,6 @@
               "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
               "serviceAccount:806222273987-ksinuueghug8u81i36lq8aof266q19hl@developer.gserviceaccount.com"
             ],
-            "folder_admins": [
-              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com"
-            ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-test",
               "protected_project_id": "fc-aou-cdr-synth-test"

--- a/terra-perf.json
+++ b/terra-perf.json
@@ -74,9 +74,6 @@
               "serviceAccount:all-of-us-rw-perf@appspot.gserviceaccount.com",
               "serviceAccount:leonardo-perf@broad-dsde-perf.iam.gserviceaccount.com",
               "serviceAccount:rawls-perf@broad-dsde-perf.iam.gserviceaccount.com"
-            ],
-            "folder_admins": [
-              "serviceAccount:all-of-us-rw-perf@appspot.gserviceaccount.com"
             ]
           }
         }

--- a/terra-prod.json
+++ b/terra-prod.json
@@ -115,9 +115,6 @@
               "serviceAccount:deploy@all-of-us-rw-prod.iam.gserviceaccount.com",
               "serviceAccount:rawls-prod@broad-dsde-prod.iam.gserviceaccount.com"
             ],
-            "folder_admins": [
-              "serviceAccount:all-of-us-rw-prod@appspot.gserviceaccount.com"
-            ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-prod",
               "protected_project_id": "fc-aou-cdr-prod"
@@ -134,9 +131,6 @@
               "serviceAccount:deploy@all-of-us-rw-stable.iam.gserviceaccount.com",
               "serviceAccount:rawls-prod@broad-dsde-prod.iam.gserviceaccount.com"
             ],
-            "folder_admins": [
-              "serviceAccount:all-of-us-rw-stable@appspot.gserviceaccount.com"
-            ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-stable",
               "protected_project_id": "fc-aou-cdr-synth-stable"
@@ -152,9 +146,6 @@
               "serviceAccount:leonardo-prod@broad-dsde-prod.iam.gserviceaccount.com",
               "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
               "serviceAccount:rawls-prod@broad-dsde-prod.iam.gserviceaccount.com"
-            ],
-            "folder_admins": [
-              "serviceAccount:all-of-us-rw-staging@appspot.gserviceaccount.com"
             ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-staging",


### PR DESCRIPTION
Reverts broadinstitute/terraform-terra#124

This currently cannot be applied due to insufficient roles for the Terraform SA - revert for now so that master reflects the current state of the world:

```
google_folder_iam_policy.folder-admin-policy["terra_prod_aou_stable"]: Creating...
Error: Error setting IAM policy for folder "folders/300547813290": googleapi: Error 403: The caller does not have permission, forbidden
  on perimeters.tf line 25, in resource "google_folder_iam_policy" "folder-admin-policy":
  25: resource "google_folder_iam_policy" "folder-admin-policy" {
Error: Error setting IAM policy for folder "folders/727685043294": googleapi: Error 403: The caller does not have permission, forbidden
  on perimeters.tf line 25, in resource "google_folder_iam_policy" "folder-admin-policy":
  25: resource "google_folder_iam_policy" "folder-admin-policy" {
Error: Error setting IAM policy for folder "folders/96867205717": googleapi: Error 403: The caller does not have permission, forbidden
  on perimeters.tf line 25, in resource "google_folder_iam_policy" "folder-admin-policy":
  25: resource "google_folder_iam_policy" "folder-admin-policy" {
```