### PR TITLE
Add aggregated perimeter log sinks

### DIFF
--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
@@ -1,0 +1,108 @@
+# Optional log sinks on projects in a Rawls service perimeter, applied at the
+# aggregate folder level. For more details, see:
+# https://docs.google.com/document/d/1gzMuZSFOgFa_usCtPHWzGdwEcfexQN70Q6uI4sy5n-E/edit
+
+locals {
+  bigquery_sink_dataset_id = "WorkspaceBigQueryLogs"
+  storage_sink_dataset_id = "WorkspaceStorageLogs"
+  dataproc_sink_dataset_id = "WorkspaceDataprocLogs"
+}
+
+data "google_project" "audit-logs-project" {
+  for_each   = var.audit_logs_project_ids
+  project_id = each.value
+}
+
+resource "google_logging_folder_sink" "bigquery-audit-sink" {
+  for_each   = var.audit_logs_project_ids
+
+  name        = "${each.key}-bigquery-audit-sink"
+  folder      = google_folder.folder[each.key].name
+  destination = "bigquery.googleapis.com/projects/${each.value}/datasets/${local.bigquery_sink_dataset_id}"
+  filter      = "logName:\"/logs/cloudaudit.googleapis.com%2Fdata_access\" AND resource.type=\"bigquery_resource\""
+
+  include_children = true
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_logging_folder_sink" "storage-audit-sink" {
+  for_each   = var.audit_logs_project_ids
+
+  name        = "${each.key}-storage-audit-sink"
+  folder      = google_folder.folder[each.key].name
+  destination = "bigquery.googleapis.com/projects/${each.value}/datasets/${local.storage_sink_dataset_id}"
+  filter      = "logName:\"/logs/cloudaudit.googleapis.com%2Fdata_access\" AND resource.type=\"gcs_bucket\""
+
+  include_children = true
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_logging_folder_sink" "dataproc-audit-sink" {
+  for_each   = var.audit_logs_project_ids
+
+  name        = "${each.key}-dataproc-audit-sink"
+  folder      = google_folder.folder[each.key].name
+  destination = "bigquery.googleapis.com/projects/${each.value}/datasets/${local.dataproc_sink_dataset_id}"
+  filter      = "resource.type=\"cloud_dataproc_cluster\" AND (logName:\"/logs/welder\" OR logName:\"/logs/jupyter\")"
+
+  include_children = true
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_bigquery_dataset" "bigquery-sink-dataset" {
+  for_each   = var.audit_logs_project_ids
+
+  project  = each.value
+  dataset_id  = local.bigquery_sink_dataset_id
+  description = "BigQuery audit log sink for projects in Terra perimeter ${each.key}"
+
+  labels = {
+    perimeter = each.key
+  }
+
+  access {
+    role   = "roles/bigquery.dataEditor"
+    user_by_email = google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity
+  }
+}
+
+resource "google_bigquery_dataset" "storage-sink-dataset" {
+  for_each   = var.audit_logs_project_ids
+
+  project  = each.value
+  dataset_id  = local.storage_sink_dataset_id
+  description = "Storage audit log sink for projects in Terra perimeter ${each.key}"
+
+  labels = {
+    perimeter = each.key
+  }
+
+  access {
+    role   = "roles/bigquery.dataEditor"
+    user_by_email = google_logging_folder_sink.storage-audit-sink[each.key].writer_identity
+  }
+}
+
+resource "google_bigquery_dataset" "dataproc-sink-dataset" {
+  for_each   = var.audit_logs_project_ids
+
+  project  = each.value
+  dataset_id  = local.dataproc_sink_dataset_id
+  description = "Dataproc audit log sink for projects in Terra perimeter ${each.key}"
+
+  labels = {
+    perimeter = each.key
+  }
+
+  access {
+    role   = "roles/bigquery.dataEditor"
+    user_by_email = google_logging_folder_sink.dataproc-audit-sink[each.key].writer_identity
+  }
+}
+

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
@@ -68,7 +68,9 @@ resource "google_bigquery_dataset" "bigquery-sink-dataset" {
 
   access {
     role   = "roles/bigquery.dataEditor"
-    user_by_email = google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity
+    user_by_email = trimprefix(
+      google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
+      "serviceAccount:")
   }
 }
 
@@ -85,7 +87,9 @@ resource "google_bigquery_dataset" "storage-sink-dataset" {
 
   access {
     role   = "roles/bigquery.dataEditor"
-    user_by_email = google_logging_folder_sink.storage-audit-sink[each.key].writer_identity
+    user_by_email = trimprefix(
+      google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
+      "serviceAccount:")
   }
 }
 
@@ -102,7 +106,9 @@ resource "google_bigquery_dataset" "dataproc-sink-dataset" {
 
   access {
     role   = "roles/bigquery.dataEditor"
-    user_by_email = google_logging_folder_sink.dataproc-audit-sink[each.key].writer_identity
+    user_by_email = trimprefix(
+      google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
+      "serviceAccount:")
   }
 }
 

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
@@ -68,9 +68,11 @@ resource "google_bigquery_dataset" "bigquery-sink-dataset" {
 
   access {
     role   = "roles/bigquery.dataEditor"
-    user_by_email = trimprefix(
+    # TODO: replace -> trimprefix once we're on TF >=0.12.17.
+    user_by_email = replace(
       google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
-      "serviceAccount:")
+      "serviceAccount:",
+      "")
   }
 }
 
@@ -87,9 +89,10 @@ resource "google_bigquery_dataset" "storage-sink-dataset" {
 
   access {
     role   = "roles/bigquery.dataEditor"
-    user_by_email = trimprefix(
+    user_by_email = replace(
       google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
-      "serviceAccount:")
+      "serviceAccount:",
+      "")
   }
 }
 
@@ -106,9 +109,10 @@ resource "google_bigquery_dataset" "dataproc-sink-dataset" {
 
   access {
     role   = "roles/bigquery.dataEditor"
-    user_by_email = trimprefix(
+    user_by_email = replace(
       google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
-      "serviceAccount:")
+      "serviceAccount:",
+      "")
   }
 }
 

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -54,6 +54,17 @@ variable "folder_admins" {
   }
 }
 
+# Sparse map of perimeter audit log project IDs. Only contains entries if a sink
+# destination has been specified.
+variable "audit_logs_project_ids" {
+  type    = map(string)
+  default = {
+    {{ range $k, $v := $perimeters }}{{ if $v.audit_logs_project_id }}
+    "{{ $k }}" = "{{ $v.audit_logs_project_id }}"
+    {{ end }}{{ end }}
+  }
+}
+
 # Sparse map of ingress bridge configurations. Only contains entries for
 # perimeters which define ingress bridges.
 variable "ingress_bridges" {

--- a/terra-dev.json
+++ b/terra-dev.json
@@ -69,6 +69,7 @@
             "folder_admins": [
               "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com"
             ],
+            "audit_logs_project_id": "fc-aou-logs-test",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-test",
               "protected_project_id": "fc-aou-cdr-synth-test"

--- a/terra-perf.json
+++ b/terra-perf.json
@@ -65,7 +65,8 @@
             ],
             "folder_admins": [
               "serviceAccount:all-of-us-rw-perf@appspot.gserviceaccount.com"
-            ]
+            ],
+            "audit_logs_project_id": "fc-aou-logs-perf"
           }
         }
       }

--- a/terra-prod.json
+++ b/terra-prod.json
@@ -117,7 +117,6 @@
             "folder_admins": [
               "serviceAccount:all-of-us-rw-prod@appspot.gserviceaccount.com"
             ],
-            "audit_logs_project_id": "fc-aou-logs-prod",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-prod",
               "protected_project_id": "fc-aou-cdr-prod"
@@ -137,7 +136,6 @@
             "folder_admins": [
               "serviceAccount:all-of-us-rw-preprod@appspot.gserviceaccount.com"
             ],
-            "audit_logs_project_id": "fc-aou-logs-preprod",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-preprod",
               "protected_project_id": "fc-aou-cdr-preprod"
@@ -157,7 +155,6 @@
             "folder_admins": [
               "serviceAccount:all-of-us-rw-stable@appspot.gserviceaccount.com"
             ],
-            "audit_logs_project_id": "fc-aou-logs-stable",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-stable",
               "protected_project_id": "fc-aou-cdr-synth-stable"
@@ -177,7 +174,6 @@
             "folder_admins": [
               "serviceAccount:all-of-us-rw-staging@appspot.gserviceaccount.com"
             ],
-            "audit_logs_project_id": "fc-aou-logs-staging",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-staging",
               "protected_project_id": "fc-aou-cdr-synth-staging"

--- a/terra-prod.json
+++ b/terra-prod.json
@@ -117,6 +117,7 @@
             "folder_admins": [
               "serviceAccount:all-of-us-rw-prod@appspot.gserviceaccount.com"
             ],
+            "audit_logs_project_id": "fc-aou-logs-prod",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-prod",
               "protected_project_id": "fc-aou-cdr-prod"
@@ -136,6 +137,7 @@
             "folder_admins": [
               "serviceAccount:all-of-us-rw-preprod@appspot.gserviceaccount.com"
             ],
+            "audit_logs_project_id": "fc-aou-logs-preprod",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-preprod",
               "protected_project_id": "fc-aou-cdr-preprod"
@@ -155,6 +157,7 @@
             "folder_admins": [
               "serviceAccount:all-of-us-rw-stable@appspot.gserviceaccount.com"
             ],
+            "audit_logs_project_id": "fc-aou-logs-stable",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-stable",
               "protected_project_id": "fc-aou-cdr-synth-stable"
@@ -174,6 +177,7 @@
             "folder_admins": [
               "serviceAccount:all-of-us-rw-staging@appspot.gserviceaccount.com"
             ],
+            "audit_logs_project_id": "fc-aou-logs-staging",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-vpc-ingest-staging",
               "protected_project_id": "fc-aou-cdr-synth-staging"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DDO-121

Design: https://docs.google.com/document/d/1gzMuZSFOgFa_usCtPHWzGdwEcfexQN70Q6uI4sy5n-E/edit

- Creates BigQuery sink datasets in target project
- Creates aggregated log sinks on the perimeter folder
- Enables log sinks for dev/perf AoU perimeters (prod to follow)
- Currently grabs:
  - Dataproc (Leo-related VM logs)
  - GCS access logs
  - BQ access logs

Applying this will require the following access (ideally on the terraform SA):
- roles/logging.configWriter (Logs Configuration Writer) on respective perimeter folders
- ~~roles/bigquery.dataOwner (BigQuery Data Owner) on audit sink projects.~~ Granted

CC @dvoet @gpolumbo-broad 