### PR TITLE
Include CDR in initial VPC-SC perimeter, add preprod

### DIFF
--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/ingress-bridges.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/ingress-bridges.tf
@@ -25,7 +25,11 @@ resource "google_access_context_manager_service_perimeter" "ingress-bridge" {
       "projects/${data.google_project.protected_project[each.key].number}"
     ]
   }
-  depends_on = [google_access_context_manager_service_perimeter.ingress-perimeter]
+  # Projects must first belong to a perimeter before a bridge can be created.
+  depends_on = [
+    google_access_context_manager_service_perimeter.ingress-perimeter,
+    google_access_context_manager_service_perimeter.service-perimeter
+  ]
 }
 
 resource "google_access_context_manager_service_perimeter" "ingress-perimeter" {

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
@@ -32,7 +32,12 @@ resource "google_access_context_manager_service_perimeter" "service-perimeter" {
   name   = "accessPolicies/${var.access_policy_name}/servicePerimeters/${each.key}"
   title  = each.key
   status {
-    resources           = []
+    resources           = each.value.has_ingress_bridge ? [
+      # If we have an ingress bridge configuration, we need to ensure the
+      # protected project is included initially. This project must also be added
+      # to the Rawls vault whitelist of perimeter projects so it isn't removed.
+      "projects/${data.google_project.ingress_project[each.key].number}"
+    ] : []
     restricted_services = each.value.restricted_services
     access_levels = [
       google_access_context_manager_access_level.access-level[each.key].name

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
@@ -36,7 +36,7 @@ resource "google_access_context_manager_service_perimeter" "service-perimeter" {
       # If we have an ingress bridge configuration, we need to ensure the
       # protected project is included initially. This project must also be added
       # to the Rawls vault whitelist of perimeter projects so it isn't removed.
-      "projects/${data.google_project.ingress_project[each.key].number}"
+      "projects/${data.google_project.protected_project[each.key].number}"
     ] : []
     restricted_services = each.value.restricted_services
     access_levels = [

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -26,6 +26,7 @@ variable "perimeters" {
   type    = map(object({
     restricted_services = list(string)
     access_member_whitelist = list(string)
+    has_ingress_bridge = bool
   }))
   default = {
     {{ range $k, $v := $perimeters }}

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -32,6 +32,7 @@ variable "perimeters" {
     "{{ $k }}" = {
       restricted_services = {{ template "toJSONStringArray" $v.restricted_services }}
       access_member_whitelist = {{ template "toJSONStringArray" $v.access_member_whitelist }}
+      has_ingress_bridge = {{ if $v.ingress_bridge }} true {{ else }} false {{ end }}
     }
     {{ end }}
   }

--- a/terra-prod.json
+++ b/terra-prod.json
@@ -119,6 +119,25 @@
               "protected_project_id": "fc-aou-cdr-prod"
             }
           },
+          "terra_prod_aou_preprod": {
+            "restricted_services": [
+              "bigquery.googleapis.com",
+              "storage.googleapis.com"
+            ],
+            "access_member_whitelist": [
+              "serviceAccount:all-of-us-rw-preprod@appspot.gserviceaccount.com",
+              "serviceAccount:leonardo-prod@broad-dsde-prod.iam.gserviceaccount.com",
+              "serviceAccount:deploy@all-of-us-rw-preprod.iam.gserviceaccount.com",
+              "serviceAccount:rawls-prod@broad-dsde-prod.iam.gserviceaccount.com"
+            ],
+            "folder_admins": [
+              "serviceAccount:all-of-us-rw-preprod@appspot.gserviceaccount.com"
+            ],
+            "ingress_bridge": {
+              "ingress_project_id": "fc-aou-vpc-ingest-preprod",
+              "protected_project_id": "fc-aou-cdr-preprod"
+            }
+          },
           "terra_prod_aou_stable": {
             "restricted_services": [
               "bigquery.googleapis.com",


### PR DESCRIPTION
Projects must belong to perimeters before a bridge is created. Therefore, for TF initialization we need to ensure that the CDR project gets included in the initial VPC-SC perimeter (Rawls will handle keeping it in there after creation).