### PR TITLE
Fix for BQ dataset ACLs on perimeter log sinks

### DIFF
--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
@@ -68,7 +68,7 @@ resource "google_bigquery_dataset" "bigquery-sink-dataset" {
 
   access {
     role   = "OWNER"
-    user_by_email = var.terraform_sa
+    user_by_email = local.terraform_sa
   }
   access {
     role   = "EDITOR"
@@ -93,7 +93,7 @@ resource "google_bigquery_dataset" "storage-sink-dataset" {
 
   access {
     role   = "OWNER"
-    user_by_email = var.terraform_sa
+    user_by_email = local.terraform_sa
   }
   access {
     role   = "EDITOR"
@@ -117,7 +117,7 @@ resource "google_bigquery_dataset" "dataproc-sink-dataset" {
 
   access {
     role   = "OWNER"
-    user_by_email = var.terraform_sa
+    user_by_email = local.terraform_sa
   }
   access {
     role   = "EDITOR"

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/log-sinks.tf
@@ -67,7 +67,11 @@ resource "google_bigquery_dataset" "bigquery-sink-dataset" {
   }
 
   access {
-    role   = "roles/bigquery.dataEditor"
+    role   = "OWNER"
+    user_by_email = var.terraform_sa
+  }
+  access {
+    role   = "EDITOR"
     # TODO: replace -> trimprefix once we're on TF >=0.12.17.
     user_by_email = replace(
       google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
@@ -88,7 +92,11 @@ resource "google_bigquery_dataset" "storage-sink-dataset" {
   }
 
   access {
-    role   = "roles/bigquery.dataEditor"
+    role   = "OWNER"
+    user_by_email = var.terraform_sa
+  }
+  access {
+    role   = "EDITOR"
     user_by_email = replace(
       google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
       "serviceAccount:",
@@ -108,7 +116,11 @@ resource "google_bigquery_dataset" "dataproc-sink-dataset" {
   }
 
   access {
-    role   = "roles/bigquery.dataEditor"
+    role   = "OWNER"
+    user_by_email = var.terraform_sa
+  }
+  access {
+    role   = "EDITOR"
     user_by_email = replace(
       google_logging_folder_sink.bigquery-audit-sink[each.key].writer_identity,
       "serviceAccount:",

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -17,6 +17,12 @@ variable "access_policy_name" {
   default = "{{env "ACCESS_POLICY_NAME"}}"
 }
 
+variable "terraform_sa" {
+  type = string
+  # XXX: Pull this dynamically from consul-template.
+  default = "terraform@broad-dsde-dev.iam.gserviceaccount.com"
+}
+
 {{ define "toJSONStringArray" }}[{{range $i, $v := .}}{{if $i}}, {{end}}{{printf "%q" $v}}{{end}}]{{ end }}
 
 {{ with $profile_json := file "/env.json" | parseJSON }}

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -17,20 +17,9 @@ variable "access_policy_name" {
   default = "{{env "ACCESS_POLICY_NAME"}}"
 }
 
-# There may be a better way of determining the Terraform SA, but this feels
-# slightly better than encoding the value twice.
-{{ with $creds_json := file "/default.sa.json" | parseJSON }}
-
-{{ $terraform_sa := "FATAL: must use service-account credentials" }}
-{{ if eq "service_account" (index $creds_json "type") }}
-  {{ $terraform_sa = index $creds_json "client_email" }}
-{{ end }}
-
-variable "terraform_sa" {
-  type = string
-  default = "{{ $terraform_sa }}"
+locals {
+  terraform_sa = jsondecode(file("default.sa.json")).client_email
 }
-{{ end }}
 
 {{ define "toJSONStringArray" }}[{{range $i, $v := .}}{{if $i}}, {{end}}{{printf "%q" $v}}{{end}}]{{ end }}
 

--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/variables.tf.ctmpl
@@ -17,11 +17,20 @@ variable "access_policy_name" {
   default = "{{env "ACCESS_POLICY_NAME"}}"
 }
 
+# There may be a better way of determining the Terraform SA, but this feels
+# slightly better than encoding the value twice.
+{{ with $creds_json := file "/default.sa.json" | parseJSON }}
+
+{{ $terraform_sa := "FATAL: must use service-account credentials" }}
+{{ if eq "service_account" (index $creds_json "type") }}
+  {{ $terraform_sa = index $creds_json "client_email" }}
+{{ end }}
+
 variable "terraform_sa" {
   type = string
-  # XXX: Pull this dynamically from consul-template.
-  default = "terraform@broad-dsde-dev.iam.gserviceaccount.com"
+  default = "{{ $terraform_sa }}"
 }
+{{ end }}
 
 {{ define "toJSONStringArray" }}[{{range $i, $v := .}}{{if $i}}, {{end}}{{printf "%q" $v}}{{end}}]{{ end }}
 


### PR DESCRIPTION
Problems:
- The only supported mechanism for managing BigQuery ACLs is an all-or-nothing list of `access` clauses.
- As a side-effect of having created the BigQuery sink, the Terraform user itself is  an owner.
- dataEditor gets turned into EDITOR by the BigQuery API, which looks like a delta as well

Here, I pick out the SA name from the incoming SA creds file to determine the active Terraform SA name, then attach that to the BigQuery dataset. If this worked, it *should* result in no changes to the current ACLs.

Process follow-up:
As part of applying a Terraform change, there should probably be a follow-up step to run `terraform plan` to determine whether there are unexpected changes.