### PR TITLE
Add Service Perimeter terra_dev_aou_test_2

### DIFF
--- a/terra-dev.json
+++ b/terra-dev.json
@@ -77,6 +77,27 @@
             },
             "sam_resource_owner_email": "all-of-us-workbench-test@appspot.gserviceaccount.com"
           },
+          "terra_dev_aou_test_2": {
+            "restricted_services": [
+              "bigquery.googleapis.com",
+              "storage.googleapis.com"
+            ],
+            "access_member_whitelist": [
+              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
+              "serviceAccount:leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com",
+              "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
+              "serviceAccount:806222273987-ksinuueghug8u81i36lq8aof266q19hl@developer.gserviceaccount.com"
+            ],
+            "folder_admins": [
+              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com"
+            ],
+            "audit_logs_project_id": "fc-aou-logs-test",
+            "ingress_bridge": {
+              "ingress_project_id": "fc-aou-vpc-ingest-test-2",
+              "protected_project_id": "fc-aou-cdr-synth-test-2"
+            },
+            "sam_resource_owner_email": "all-of-us-workbench-test@appspot.gserviceaccount.com"
+          },
           "terra_dev_baseline_test": {
             "restricted_services": ["bigquery.googleapis.com"],
             "access_member_whitelist": [

--- a/terra-dev.json
+++ b/terra-dev.json
@@ -91,7 +91,6 @@
             "folder_admins": [
               "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com"
             ],
-            "audit_logs_project_id": "fc-aou-logs-test",
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-cdr-ingest-test-2",
               "protected_project_id": "fc-aou-cdr-synth-test-2"

--- a/terra-dev.json
+++ b/terra-dev.json
@@ -93,7 +93,7 @@
             ],
             "audit_logs_project_id": "fc-aou-logs-test",
             "ingress_bridge": {
-              "ingress_project_id": "fc-aou-vpc-ingest-test-2",
+              "ingress_project_id": "fc-aou-cdr-ingest-test-2",
               "protected_project_id": "fc-aou-cdr-synth-test-2"
             },
             "sam_resource_owner_email": "all-of-us-workbench-test@appspot.gserviceaccount.com"


### PR DESCRIPTION
We will eventually need to add a second service perimeter and folder to all AoU environments, as part of our Controlled Tier access restrictions.  This PR adds one to AoU Test so we can prototype.  Similar to PRs #130 and #131.

Note: project naming patterns do not match exactly.  This is OK for the prototype.