### PR TITLE
[RW-6285] VPC-SC changes to support genomics cohort extraction

### DIFF
--- a/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
+++ b/profiles/rawls-service-perimeters/terraform/rawls-service-perimeters/perimeters.tf
@@ -30,6 +30,25 @@ resource "google_folder_iam_binding" "admin-bucket-writer" {
   members = each.value.members
 }
 
+# BigQuery roles are necessary to support genomics extraction jobs, which bill
+# BigQuery costs to the researcher project. Owners will have these roles, so
+# this is well aligned with the above premise.
+resource "google_folder_iam_binding" "admin-bigquery-job-user" {
+  for_each = var.folder_admins
+
+  folder = google_folder.folder[each.key].name
+  role = "roles/bigquery.jobUser"
+  members = each.value.members
+}
+
+resource "google_folder_iam_binding" "admin-bigquery-read-session-user" {
+  for_each = var.folder_admins
+
+  folder = google_folder.folder[each.key].name
+  role = "roles/bigquery.readSessionUser"
+  members = each.value.members
+}
+
 resource "google_folder_iam_binding" "admin-billing-manager" {
   for_each = var.folder_admins
 

--- a/terra-dev.json
+++ b/terra-dev.json
@@ -91,12 +91,14 @@
             ],
             "access_member_whitelist": [
               "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
+              "serviceAccount:pet-118217329794842274136@aou-wgs-cohort-extraction.iam.gserviceaccount.com",
               "serviceAccount:leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com",
               "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
               "serviceAccount:806222273987-ksinuueghug8u81i36lq8aof266q19hl@developer.gserviceaccount.com"
             ],
             "folder_admins": [
-              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com"
+              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
+              "serviceAccount:pet-118217329794842274136@aou-wgs-cohort-extraction.iam.gserviceaccount.com"
             ],
             "ingress_bridge": {
               "ingress_project_id": "fc-aou-cdr-ingest-test-2",

--- a/terra-dev.json
+++ b/terra-dev.json
@@ -64,12 +64,14 @@
             ],
             "access_member_whitelist": [
               "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
+              "serviceAccount:pet-118217329794842274136@aou-wgs-cohort-extraction.iam.gserviceaccount.com",
               "serviceAccount:leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com",
               "serviceAccount:circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
               "serviceAccount:806222273987-ksinuueghug8u81i36lq8aof266q19hl@developer.gserviceaccount.com"
             ],
             "folder_admins": [
-              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com"
+              "serviceAccount:all-of-us-workbench-test@appspot.gserviceaccount.com",
+              "serviceAccount:pet-118217329794842274136@aou-wgs-cohort-extraction.iam.gserviceaccount.com"
             ],
             "audit_logs_project_id": "fc-aou-logs-test",
             "ingress_bridge": {


### PR DESCRIPTION
[Design doc](https://docs.google.com/document/d/1IeHVZt7N2q_kMDFhUAYBOLFzf8fHNu8LgjSGtPIVUAg/edit?ts=5ff5ef06#). The end goal here is to support dynamic genomic cohort extraction implemented on the backend by Cromwell.

- Add BigQuery job user and read session roles, to allow the extraction SA to take BigQuery actions which are billed against researcher projects.
- Add the RW extraction pet SA to the admin / access level, in order to permit backend Cromwell execution from outside the perimeter (Cromwell does not support execution within VPC-SC currently).
- The new extraction SA is added in test/dev only. Other environments will follow later.