### PR TITLE
[CA-1370] add condition on all policy bindings

### DIFF
--- a/scripts/project-setup-scripts/add-folder-roles-for-service-accounts-and-terra-billing-and-test-users.sh
+++ b/scripts/project-setup-scripts/add-folder-roles-for-service-accounts-and-terra-billing-and-test-users.sh
@@ -49,23 +49,23 @@ fi
 
 RAWLS_SA=$(docker run -e VAULT_TOKEN="$(cat ~/.vault-token)" -it broadinstitute/dsde-toolbox:dev vault read -field="client_email" secret/dsde/firecloud/${vault_env}/rawls/rawls-account.json)
 CROMWELL_SA=$(docker run -e VAULT_TOKEN="$(cat ~/.vault-token)" -it broadinstitute/dsde-toolbox:dev vault read -field="client_email" secret/dsde/firecloud/${vault_env}/cromwell/cromwell-account.json)
-gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=serviceAccount:"${RAWLS_SA}" --role=roles/editor
-gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=serviceAccount:"${RAWLS_SA}" --role=roles/resourcemanager.projectMover
+gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=serviceAccount:"${RAWLS_SA}" --role=roles/editor --condition=None
+gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=serviceAccount:"${RAWLS_SA}" --role=roles/resourcemanager.projectMover --condition=None
 RAWLS_CONDITION_FILE="rawls-sa-condition-file.yaml"
 gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=serviceAccount:"${RAWLS_SA}" --role=roles/resourcemanager.projectIamAdmin --condition-from-file=${RAWLS_CONDITION_FILE} # required to set policies on google projects from the Buffer service
-gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=serviceAccount:"${CROMWELL_SA}" --role=roles/editor
+gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=serviceAccount:"${CROMWELL_SA}" --role=roles/editor --condition=None
 
 
 # prod only needs the terra-billing group
 if [[ "${ENV}" == "prod" ]]; then
-  gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:terra-billing@firecloud.org --role=roles/owner
+  gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:terra-billing@firecloud.org --role=roles/owner  --condition=None
 else # for non-prod envs, add terra-billing as well as project owner groups
-  gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:terra-billing@test.firecloud.org --role=roles/owner
-  gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:firecloud-project-owners@test.firecloud.org --role=roles/owner
+  gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:terra-billing@test.firecloud.org --role=roles/owner  --condition=None
+  gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:firecloud-project-owners@test.firecloud.org --role=roles/owner  --condition=None
 
   # for the QA env, add quality.firecloud.org users as well
   if [[ "${ENV}" == "fiab-qa" ]]; then
-    gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:terra-billing@quality.firecloud.org --role=roles/owner
-    gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:firecloud-project-owners@quality.firecloud.org --role=roles/owner
+    gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:terra-billing@quality.firecloud.org --role=roles/owner  --condition=None
+    gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:firecloud-project-owners@quality.firecloud.org --role=roles/owner  --condition=None
   fi
 fi

--- a/scripts/project-setup-scripts/add-folder-roles-for-service-accounts-and-terra-billing-and-test-users.sh
+++ b/scripts/project-setup-scripts/add-folder-roles-for-service-accounts-and-terra-billing-and-test-users.sh
@@ -6,8 +6,7 @@
 
 set -euxo pipefail
 
-
-ENV=$1
+ENV=${1:-""}
 VALID_ENVS="Valid ENVs:
         dev
         fiab-dev

--- a/scripts/project-setup-scripts/rawls-sa-condition-file.yaml
+++ b/scripts/project-setup-scripts/rawls-sa-condition-file.yaml
@@ -1,5 +1,5 @@
 # Conditions for granting role "roles/resourcemanager.projectIamAdmin" on the Rawls SA
-## Inlining this requres extra escaping https://cloud.google.com/sdk/gcloud/reference/topic/escaping which makes it hard to read/maintain
+# Note: I opted for this approach because inlining the condition requres extra escaping (https://cloud.google.com/sdk/gcloud/reference/topic/escaping) which makes it annoying to read/maintain.
 
 "title": "only_custom_roles"
 "description": "Only allow adding specified custom iam roles to projects in this folder."

--- a/scripts/project-setup-scripts/rawls-sa-condition-file.yaml
+++ b/scripts/project-setup-scripts/rawls-sa-condition-file.yaml
@@ -1,5 +1,5 @@
 # Conditions for granting role "roles/resourcemanager.projectIamAdmin" on the Rawls SA
-# Note: I opted for this approach because inlining the condition requres extra escaping (https://cloud.google.com/sdk/gcloud/reference/topic/escaping) which makes it annoying to read/maintain.
+# Note: I opted for this approach because inlining the condition requires extra escaping (https://cloud.google.com/sdk/gcloud/reference/topic/escaping) which makes it annoying to read/maintain.
 
 "title": "only_custom_roles"
 "description": "Only allow adding specified custom iam roles to projects in this folder."


### PR DESCRIPTION
followup to: https://github.com/broadinstitute/terraform-terra/pull/152
fixes an issue where now all new policy bindings need to specify a condition, even if it is `None`

the issue was that if any existing iam policy has a condition, then all new policy updates require a condition as well.
```
+ gcloud resource-manager folders add-iam-policy-binding 599966635789 --member=group:firecloud-project-owners@test.firecloud.org --role=roles/owner
 [1] EXPRESSION=api.getAttribute('iam.googleapis.com/modifiedGrantsByRole',[]).hasOnly( ['roles/terra_billing_project_owner','roles/terra_workspace_can_compute','roles/terraBucketReader','roles/terraBucketWriter']), TITLE=only_custom_roles, DESCRIPTION=Only allow adding specified custom iam roles to projects in this folder.
 [2] None
 [3] Specify a new condition
The policy contains bindings with conditions, so specifying a
condition is required when adding a binding. Please specify a
condition.:  2
```

Tested against fiab-dev and dev