### PR TITLE
[CA-1435] fix role name in conditional

### DIFF
--- a/scripts/project-setup-scripts/rawls-sa-condition-file.yaml
+++ b/scripts/project-setup-scripts/rawls-sa-condition-file.yaml
@@ -4,4 +4,4 @@
 "title": "only_custom_roles"
 "description": "Only allow adding specified custom iam roles to projects in this folder."
 "expression": "api.getAttribute('iam.googleapis.com/modifiedGrantsByRole',[]).hasOnly(
-  ['roles/terra_billing_project_owner','roles/terra_workspace_can_compute','roles/terraBucketReader','roles/terraBucketWriter'])"
+  ['terra_billing_project_owner','terra_workspace_can_compute','terraBucketReader','terraBucketWriter'])"


### PR DESCRIPTION
we found that there were some permission issues when updating the iam on QA fiab runs.

On a hunch, I tried removing the conditional statement in the console. After that, the test passed.

The conditional apparently didn't matter on the dev fiab, but with this change, QA fiabs (and other envs) should be unblocked.


I removed `roles/` after seeing this:
```
✗ gcloud iam roles describe roles/terra_billing_project_owner --organization=400176686919
ERROR: (gcloud.iam.roles.describe) Invalid value for [ROLE_ID]: The role id that starts with 'roles/' only stands for curated role. Should not specify the project or organization for curated roles

✗ gcloud iam roles describe terra_billing_project_owner --organization=206744735509
description: permissions for billing project owners
etag: BwW-YwwBLIs=
includedPermissions:
- billing.resourceCosts.get
- compute.instances.get
- compute.instances.list
- compute.projects.get
- iam.roles.get
- iam.roles.list
- storage.buckets.list
- workflows.workflows.get
- workflows.workflows.list
name: organizations/206744735509/roles/terra_billing_project_owner
stage: GA
title: terra_billing_project_owner
```

https://broadworkbench.atlassian.net/browse/CA-1435

---

tests pass with this change
https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/51426/