### PR TITLE
[CA-1443] add fcprojectowners (admin group) to prod, remove extraneous groups on qa folder

### DIFF
--- a/scripts/project-setup-scripts/add-folder-roles-for-service-accounts-and-terra-billing-and-test-users.sh
+++ b/scripts/project-setup-scripts/add-folder-roles-for-service-accounts-and-terra-billing-and-test-users.sh
@@ -66,4 +66,4 @@ gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=s
 gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:terra-billing@${APPS_DOMAIN} --role=roles/owner  --condition=None
 gcloud resource-manager folders add-iam-policy-binding "${FOLDER_ID}" --member=group:firecloud-project-owners@${APPS_DOMAIN} --role=roles/owner  --condition=None
 
-echo "Done"
+echo "Success"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CA-1443

I'm not sure why there was separate logic for QA and prod envs, but projects on prod should be administered by the admin group (`firecloud-project-owners@${APPS_DOMAIN}`) and I think it's ok if the QA env is administered only by the qa.fc.o admin group and not the test.fc.o admin group.

---

verifying that qa fiabs still work ok with this change (after removing the test.fc.o admin group and test.fc.o billing group from the qa folder) in this job: https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/51739/

kicked off a new run because of a flaky orch/gpalloc failure in the previous run
https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/51745/