### PR TITLE
CA-1620 undocumented permissions to view Quota

### DIFF
--- a/scripts/project-setup-scripts/terra-billing-project-owner.yaml
+++ b/scripts/project-setup-scripts/terra-billing-project-owner.yaml
@@ -4,6 +4,8 @@ stage: "GA"
 includedPermissions:
 # When adding permissions, you should comment with what the permission is used for and if possible a Jira link
 # explaining why the permission is needed.
+# START carry-over permissions from when used to grant Billing Project Owners the general role `Viewer` which included
+#     LOTS of permissions that we did not need to grant.  These are what was determined to be needed per: https://broadworkbench.atlassian.net/browse/CA-1180
 - billing.resourceCosts.get
 - compute.instances.get
 - compute.instances.list
@@ -14,9 +16,10 @@ includedPermissions:
 - storage.buckets.list
 - workflows.workflows.get
 - workflows.workflows.list
+# END
 # Start permissions for: View Project Quotas - https://broadworkbench.atlassian.net/browse/CA-1620
 - monitoring.timeSeries.list
 - serviceusage.quotas.get
 - serviceusage.services.get
 - serviceusage.services.list
-# End permissions for: View Project Quotas
+# END

--- a/scripts/project-setup-scripts/terra-billing-project-owner.yaml
+++ b/scripts/project-setup-scripts/terra-billing-project-owner.yaml
@@ -2,7 +2,8 @@ title: "terra_billing_project_owner"
 description: "permissions for billing project owners"
 stage: "GA"
 includedPermissions:
-# <viewer> Start of permissions included as part of roles/viewer
+# When adding permissions, you should comment with what the permission is used for and if possible a Jira link
+# explaining why the permission is needed.
 - billing.resourceCosts.get
 - compute.instances.get
 - compute.instances.list
@@ -10,8 +11,12 @@ includedPermissions:
 - iam.roles.get
 - iam.roles.list
 - iam.serviceAccounts.list
-- serviceusage.quotas.get
 - storage.buckets.list
 - workflows.workflows.get
 - workflows.workflows.list
-# </viewer> End of permissions included as part of roles/viewer
+# Start permissions for: View Project Quotas - https://broadworkbench.atlassian.net/browse/CA-1620
+- monitoring.timeSeries.list
+- serviceusage.quotas.get
+- serviceusage.services.get
+- serviceusage.services.list
+# End permissions for: View Project Quotas

--- a/scripts/project-setup-scripts/terra-workspace-can-compute.yaml
+++ b/scripts/project-setup-scripts/terra-workspace-can-compute.yaml
@@ -2,7 +2,8 @@ title: "terra_workspace_can_compute"
 description: "permissions for users with can-compute access on Terra workspaces"
 stage: "GA"
 includedPermissions:
-# Add permissions for the roles we need:
+# When adding permissions, you should comment with what the permission is used for and if possible a Jira link
+# explaining why the permission is needed.
 ##roles/bigquery.jobUser (updated 2/10/2021)
 - bigquery.jobs.create
 - resourcemanager.projects.get

--- a/scripts/project-setup-scripts/update-custom-iam-roles-for-projects.sh
+++ b/scripts/project-setup-scripts/update-custom-iam-roles-for-projects.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #create custom roles in each environment's google project
 
-set -euxo pipefail
+set -euo pipefail
 
 # todo: convert this to Terraform as part of https://broadworkbench.atlassian.net/browse/CA-1195
 
-ORGANIZATION_ID=$1
+ORGANIZATION_ID=${1:-""}
 
 if [[ -z "${ORGANIZATION_ID}" ]]
 then
@@ -17,6 +17,9 @@ then
        "
   exit 1
 else
+  echo "Overwriting custom role 'terra-workspace-can-compute' in Organization: ${ORGANIZATION_ID}"
   gcloud iam roles update terra_workspace_can_compute --organization=${ORGANIZATION_ID} --file=terra-workspace-can-compute.yaml
+  echo "---------------------------------------------"
+  echo "Overwriting custom role 'terra_billing_project_owner' in for Organization: ${ORGANIZATION_ID}"
   gcloud iam roles update terra_billing_project_owner --organization=${ORGANIZATION_ID} --file=terra-billing-project-owner.yaml
 fi


### PR DESCRIPTION
Per Google Support, there are additional permissions needed to be able to view Quota information in the Console UI vs. `gcloud`.  (Google said they will update the documentation)

Additionally, I made a view minor ease of use updates to the `update-custom-iam-roles-for-projects.sh` to make it so that calling the script with no arguments will show usage, and so that commands are not echoed in order to make it easier to parse the output from the commands.  

And finally, instead of alpha sorting the permissions, I have added some comments to explaining why the permissions are needed and what they are used for.  I propose that we keep this up going forward for all permissions in both role definitions.